### PR TITLE
fix: `crate_type` -> `crate-type` warning

### DIFF
--- a/bindings/java/rust_code/Cargo.toml
+++ b/bindings/java/rust_code/Cargo.toml
@@ -15,4 +15,4 @@ hex = { workspace = true }
 c_peerdas_kzg = { workspace = true }
 
 [lib]
-crate_type = ["cdylib"]
+crate-type = ["cdylib"]


### PR DESCRIPTION
Partially solves #83 