### PR TITLE
chore: remove unused cargo config file

### DIFF
--- a/.cargo/config.node.cross.toml
+++ b/.cargo/config.node.cross.toml
@@ -1,5 +1,0 @@
-[target.aarch64-unknown-linux-musl]
-linker = "aarch64-linux-musl-gcc"
-rustflags = ["-C", "target-feature=-crt-static"]
-[target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
We recently modified the node release workflow to no longer need this file