### PR TITLE
fix: put workflow dispatch and push events in a separate group

### DIFF
--- a/.github/workflows/release-csharp-bindings.yml
+++ b/.github/workflows/release-csharp-bindings.yml
@@ -22,6 +22,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && 'manual' || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build - ${{ matrix.target }}

--- a/.github/workflows/release-java-bindings.yml
+++ b/.github/workflows/release-java-bindings.yml
@@ -22,6 +22,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && 'manual' || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build - ${{ matrix.target }}

--- a/.github/workflows/release-nim-bindings.yml
+++ b/.github/workflows/release-nim-bindings.yml
@@ -8,7 +8,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && 'manual' || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release-node-bindings.yml
+++ b/.github/workflows/release-node-bindings.yml
@@ -8,7 +8,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && 'manual' || github.ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/release-rust-crates.yml
+++ b/.github/workflows/release-rust-crates.yml
@@ -20,7 +20,7 @@ on:
           - none
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && 'manual' || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This means that on a release, a workflow dispatch should not cancel out a push event on master