### PR TITLE
chore: remove cross.toml file

### DIFF
--- a/.cargo/config.cross.toml
+++ b/.cargo/config.cross.toml
@@ -1,9 +1,0 @@
-# On mac, this linker can be installed with `brew install SergioBenitez/osxct/x86_64-unknown-linux-gnu`
-[target.x86_64-unknown-linux-gnu]
-linker = "x86_64-unknown-linux-gnu-gcc"
-
-# On mac this linker can be installed with:
-# - `brew tap messense/homebrew-macos-cross-toolchains`
-# - `brew install aarch64-unknown-linux-gnu`
-[target.aarch64-unknown-linux-gnu]
-linker = "aarch64-unknown-linux-gnu-gcc"


### PR DESCRIPTION
For cross compilation, our CI has moved to using zig, so we no longer use the cross file for setting up the linker during cross compilation