### PR TITLE
chore: change infallible error to an assert

### DIFF
--- a/eip7594/src/errors.rs
+++ b/eip7594/src/errors.rs
@@ -63,11 +63,6 @@ pub enum VerifierError {
         num_cells_received: usize,
         max_cells_needed: usize,
     },
-    CellDoesNotContainEnoughBytes {
-        cell_index: CellIndex,
-        num_bytes: usize,
-        expected_num_bytes: usize,
-    },
     CellIndexOutOfRange {
         cell_index: CellIndex,
         max_number_of_cells: u64,

--- a/eip7594/src/prover.rs
+++ b/eip7594/src/prover.rs
@@ -13,7 +13,7 @@ use crate::{
         deserialize_blob_to_scalars, serialize_cells_and_proofs, serialize_g1_compressed,
     },
     trusted_setup::TrustedSetup,
-    BlobRef, Cell, CellIndex, CellRef, KZGCommitment, KZGProof, DASContext,
+    BlobRef, Cell, CellIndex, CellRef, DASContext, KZGCommitment, KZGProof,
 };
 
 /// Context object that is used to call functions in the prover API.

--- a/eip7594/src/verifier.rs
+++ b/eip7594/src/verifier.rs
@@ -271,15 +271,10 @@ mod validation {
         }
 
         // Check that each cell has the right amount of bytes
+        //
+        // This should be infallible.
         for (i, cell) in cells.iter().enumerate() {
-            if cell.len() != BYTES_PER_CELL {
-                // TODO: This check should always be true
-                return Err(VerifierError::CellDoesNotContainEnoughBytes {
-                    cell_index: cell_indices[i],
-                    num_bytes: cell.len(),
-                    expected_num_bytes: BYTES_PER_CELL,
-                });
-            }
+            assert_eq!(cell.len(), BYTES_PER_CELL, "the number of bytes in a cell should always equal {} since the type is a reference to an array. Check cell at index {}", BYTES_PER_CELL, i);
         }
 
         // Check that we have no duplicate cell indices


### PR DESCRIPTION
This should never be hit, we leave it in since the decision on whether to switch to a vector has not been finalized yet.

It was added initially because cells used to be &[u8]