### PR TITLE
chore: remove TODO on discrepancy between number and bigint

### DIFF
--- a/bindings/node/__test__/index.spec.ts
+++ b/bindings/node/__test__/index.spec.ts
@@ -19,7 +19,6 @@ const RECOVER_CELLS_AND_KZG_PROOFS_TEST = "../../test_vectors/recover_cells_and_
 
 type BlobToKzgCommitmentTest = TestMeta<{ blob: string }, string>;
 type ComputeCellsAndKzgProofsTest = TestMeta<{ blob: string }, string[][]>;
-// TODO: number here is incorrect, but it might be worthwhile to change the type in the specs instead
 type VerifyCellKzgProofBatchTest = TestMeta<
   { commitments: string[]; cell_indices: number[]; cells: string[]; proofs: string[] },
   boolean


### PR DESCRIPTION
This discrepancy only happens within tests, so this is okay to have