### PR TITLE
chore: remove python from Java workflow

### DIFF
--- a/.github/workflows/release-java-bindings.yml
+++ b/.github/workflows/release-java-bindings.yml
@@ -130,12 +130,6 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY_JAVA_PUBLISHING }}
           passphrase: ${{ secrets.GPG_PASSPHRASE_JAVA_PUBLISHING }}
 
-      # TODO: check if python is needed
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-
       - name: Publish Java package to Maven Central
         working-directory: bindings/java/java_code
         env:


### PR DESCRIPTION
I don't believe Python is needed, atleast not explicitly. Putting up this PR to remove it and see if it breaks anything.