### PR TITLE
chore: Remove todo pertaining to generalizing `vector_mul`

### DIFF
--- a/cryptography/kzg_multi_open/src/fk20/toeplitz.rs
+++ b/cryptography/kzg_multi_open/src/fk20/toeplitz.rs
@@ -237,8 +237,6 @@ impl DenseMatrix {
     ///
     /// This method allows for matrix-vector multiplication with custom types and
     /// inner product operations.
-    ///
-    /// This is useful for multiplying G1 points TODO: Check if we need this generalize version
     fn vector_mul<T>(
         self,
         vector: Vec<T>,


### PR DESCRIPTION
This code is only called during tests, so whether it is generalized or not is insignificant