### PR TITLE
chore: remove serde_yaml deprecation notice

### DIFF
--- a/eip7594/Cargo.toml
+++ b/eip7594/Cargo.toml
@@ -21,7 +21,8 @@ serde_json = "1"
 criterion = "0.5.1"
 rand = "0.8.4"
 hex = "0.4.3"
-#TODO: note that serde_yaml is now deprecated
+# Serde-yaml has been deprecated, however since we only 
+# use it for tests, we will not update it.
 serde_yaml = "0.9.34"
 
 [[bench]]


### PR DESCRIPTION
serde_yaml is only used in tests and is not broken, so we can remove the TODO that was added since it does not pose a threat