### PR TITLE
chore: Only use c-eth-kzg in java crate

### DIFF
--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -16,7 +16,7 @@ pub use rust_eth_kzg::constants::{
     BYTES_PER_BLOB, BYTES_PER_CELL, BYTES_PER_COMMITMENT, BYTES_PER_FIELD_ELEMENT,
     CELLS_PER_EXT_BLOB, FIELD_ELEMENTS_PER_BLOB,
 };
-use rust_eth_kzg::Error;
+pub use rust_eth_kzg::Error;
 
 /*
  * Note: All methods in this file have been prefixed with `eth_kzg`.

--- a/bindings/java/rust_code/Cargo.toml
+++ b/bindings/java/rust_code/Cargo.toml
@@ -10,7 +10,6 @@ repository = { workspace = true }
 
 [dependencies]
 jni = "^0.21.1"
-rust_eth_kzg = { workspace = true }
 hex = { workspace = true }
 c_eth_kzg = { workspace = true }
 

--- a/bindings/java/rust_code/src/errors.rs
+++ b/bindings/java/rust_code/src/errors.rs
@@ -1,4 +1,4 @@
-use rust_eth_kzg::Error as KZGError;
+use c_eth_kzg::Error as KZGError;
 
 #[derive(Debug)]
 pub enum Error {

--- a/bindings/java/rust_code/src/lib.rs
+++ b/bindings/java/rust_code/src/lib.rs
@@ -1,6 +1,5 @@
 use c_eth_kzg::DASContext;
-use jni::objects::JObjectArray;
-use jni::objects::{JByteArray, JClass, JLongArray, JObject, JValue};
+use jni::objects::{JByteArray, JClass, JLongArray, JObject, JObjectArray, JValue};
 use jni::sys::{jboolean, jlong};
 use jni::JNIEnv;
 
@@ -12,7 +11,6 @@ pub extern "system" fn Java_ethereum_cryptography_LibEthKZG_DASContextNew(
     _env: JNIEnv,
     _class: JClass,
 ) -> jlong {
-    // TODO: Switch to using the Rust DASContext object
     c_eth_kzg::eth_kzg_das_context_new() as jlong
 }
 
@@ -22,7 +20,6 @@ pub extern "system" fn Java_ethereum_cryptography_LibEthKZG_DASContextDestroy(
     _class: JClass,
     ctx_ptr: jlong,
 ) {
-    // TODO: Switch to using the Rust DASContext object
     c_eth_kzg::eth_kzg_das_context_free(ctx_ptr as *mut DASContext);
 }
 


### PR DESCRIPTION
This removes usage of rust-eth-kzg and officially only uses the c-eth-kzg API. I don't think it matters too much, which one of these we use out of rust-eth-kzg and c-eth-kzg