### PR TITLE
chore: use echo to set the npmregistry for yarn and npm

### DIFF
--- a/.github/workflows/release-node-bindings.yml
+++ b/.github/workflows/release-node-bindings.yml
@@ -211,8 +211,6 @@ jobs:
       - name: Publish
         if: ${{ inputs.release-type != 'none' && github.event_name == 'workflow_dispatch' }}
         run: |
-          # TODO: We could remove the yarnpkg registry and set the npmregistry
-          # TODO: globally, by doing: yarn config set registry <registry-url>
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
           echo "//registry.yarnpkg.com/:_authToken=$NPM_TOKEN" >> ~/.npmrc
           


### PR DESCRIPTION
Removes the TODO as its okay to set the npm registry by using echo