### PR TITLE
chore: remove Java TODO in build script

### DIFF
--- a/bindings/csharp/rust_code/build.rs
+++ b/bindings/csharp/rust_code/build.rs
@@ -25,7 +25,7 @@ fn main() {
         .csharp_class_name("NativeMethods")
         .csharp_use_nint_types(false)
         .generate_csharp_file(path_to_output_file)
-        .unwrap();
+        .expect("csharp bindgen failed to generate bindgen file");
 }
 
 fn path_to_bindings_folder() -> PathBuf {

--- a/bindings/java/rust_code/build.rs
+++ b/bindings/java/rust_code/build.rs
@@ -25,7 +25,6 @@ fn main() {
     }
     let output = command.output().unwrap();
 
-    // TODO: check if we need this in other build.rs scripts
     if !output.status.success() {
         let output = std::str::from_utf8(&output.stderr).unwrap();
         panic!("{}", output)


### PR DESCRIPTION
The java build script is the only script to call a binary `javac` so its the only one we need to explicitly check for its status.

Ideally, we didn't need to do this and we could use some sort of library