### PR TITLE
chore: Remove TODO note on `write_to_2d_slice`

### DIFF
--- a/bindings/c/src/pointer_utils.rs
+++ b/bindings/c/src/pointer_utils.rs
@@ -50,7 +50,6 @@ pub(crate) fn write_to_slice<T: Copy>(ptr: *mut T, data: &[T]) {
 }
 
 /// Write `data` to a 2D slice starting at `ptr`
-// TODO: the data parameter might be too complicated, investigate simplifying it
 pub(crate) fn write_to_2d_slice<T: Copy, const N: usize>(
     ptr: *mut *mut T,
     data: [impl AsRef<[T]>; N],


### PR DESCRIPTION
We could possibly remove the need for this by passing the different reference arrays as slices, but this seems not completely necessary