### PR TITLE
chore(rust)!: Rename `recover_cells_and_proofs` -> `recover_cells_and_kzg_proofs`

### DIFF
--- a/bindings/c/src/recover_cells_and_kzg_proofs.rs
+++ b/bindings/c/src/recover_cells_and_kzg_proofs.rs
@@ -24,7 +24,7 @@ pub(crate) fn _recover_cells_and_proofs(
     // Computation
     //
     let (recovered_cells, recovered_proofs) = ctx
-        .recover_cells_and_proofs(cell_indices.to_vec(), cells)
+        .recover_cells_and_kzg_proofs(cell_indices.to_vec(), cells)
         .map_err(|err| CResult::with_error(&format!("{:?}", err)))?;
     let recovered_cells_unboxed = recovered_cells.map(|cell| cell.to_vec());
 

--- a/bindings/java/rust_code/src/lib.rs
+++ b/bindings/java/rust_code/src/lib.rs
@@ -164,7 +164,7 @@ fn recover_cells_and_kzg_proofs<'local>(
         .map(|cell| slice_to_array_ref(cell, "cell"))
         .collect::<Result<_, _>>()?;
 
-    let (recovered_cells, recovered_proofs) = ctx.recover_cells_and_proofs(cell_ids, cells)?;
+    let (recovered_cells, recovered_proofs) = ctx.recover_cells_and_kzg_proofs(cell_ids, cells)?;
     let recovered_cells = recovered_cells.map(|cell| *cell);
     cells_and_proofs_to_jobject(env, &recovered_cells, &recovered_proofs).map_err(Error::from)
 }

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -134,7 +134,7 @@ impl DASContextJs {
       .collect::<Result<_, _>>()?;
 
     let (cells, proofs) = ctx
-      .recover_cells_and_proofs(cell_indices, cells)
+      .recover_cells_and_kzg_proofs(cell_indices, cells)
       .map_err(|err| {
         Error::from_reason(format!(
           "failed to compute recover_cells_and_kzg_proofs: {:?}",

--- a/eip7594/benches/benchmark.rs
+++ b/eip7594/benches/benchmark.rs
@@ -66,12 +66,12 @@ pub fn bench_recover_cells_and_compute_kzg_proofs(c: &mut Criterion) {
         let ctx = DASContext::with_threads(&trusted_setup, num_threads);
         c.bench_function(
             &format!(
-                "worse-case recover_cells_and_compute_proofs - NUM_THREADS: {}",
+                "worse-case recover_cells_and_kzg_proofs - NUM_THREADS: {}",
                 num_threads
             ),
             |b| {
                 b.iter(|| {
-                    ctx.recover_cells_and_proofs(
+                    ctx.recover_cells_and_kzg_proofs(
                         half_cell_indices.to_vec(),
                         half_cells.to_vec(),
                     )

--- a/eip7594/src/prover.rs
+++ b/eip7594/src/prover.rs
@@ -109,7 +109,7 @@ impl DASContext {
     ///
     // Note: The fact that we recover the polynomial for the bit-reversed version of the blob
     // is irrelevant.
-    pub fn recover_cells_and_proofs(
+    pub fn recover_cells_and_kzg_proofs(
         &self,
         cell_indices: Vec<CellIndex>,
         cells: Vec<CellRef>,

--- a/eip7594/tests/recover_cells_and_kzg_proofs.rs
+++ b/eip7594/tests/recover_cells_and_kzg_proofs.rs
@@ -78,7 +78,7 @@ mod serde_ {
 
 const TEST_DIR: &str = "../test_vectors/recover_cells_and_kzg_proofs";
 #[test]
-fn test_recover_cells_and_proofs() {
+fn test_recover_cells_and_kzg_proofs() {
     let test_files = collect_test_files(TEST_DIR).unwrap();
 
     let ctx = rust_eth_kzg::DASContext::default();
@@ -102,7 +102,7 @@ fn test_recover_cells_and_proofs() {
             }
         };
 
-        match ctx.recover_cells_and_proofs(test.input_cell_indices, input_cells) {
+        match ctx.recover_cells_and_kzg_proofs(test.input_cell_indices, input_cells) {
             Ok((cells, proofs)) => {
                 let expected_proofs_and_cells = test.proofs_and_cells.unwrap();
 


### PR DESCRIPTION
Renaming so that it matches the specs