### PR TITLE
feat!: Allow downstream users to avoid the precomputations that are needed for the FixedBaseMSM algorithm in FK20

### DIFF
--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -5,6 +5,7 @@ mod compute_cells_and_kzg_proofs;
 use compute_cells_and_kzg_proofs::_compute_cells_and_kzg_proofs;
 
 mod verify_cells_and_kzg_proofs_batch;
+use rust_eth_kzg::constants::RECOMMENDED_PRECOMP_WIDTH;
 use verify_cells_and_kzg_proofs_batch::_verify_cell_kzg_proof_batch;
 
 mod recover_cells_and_kzg_proofs;
@@ -58,7 +59,15 @@ impl Deref for DASContext {
 /// by calling `eth_kzg_das_context_free`.
 #[no_mangle]
 pub extern "C" fn eth_kzg_das_context_new() -> *mut DASContext {
-    let ctx = Box::<DASContext>::default();
+    let ctx = Box::new(DASContext {
+        inner: rust_eth_kzg::DASContext::with_threads(
+            &rust_eth_kzg::TrustedSetup::default(),
+            1,
+            rust_eth_kzg::UsePrecomp::Yes {
+                width: RECOMMENDED_PRECOMP_WIDTH,
+            },
+        ),
+    });
     Box::into_raw(ctx)
 }
 

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -6,7 +6,10 @@ use napi::{
 };
 use napi_derive::napi;
 
-use rust_eth_kzg::{constants, DASContext};
+use rust_eth_kzg::{
+  constants::{self, RECOMMENDED_PRECOMP_WIDTH},
+  DASContext, TrustedSetup, UsePrecomp,
+};
 
 #[napi]
 pub const BYTES_PER_COMMITMENT: u32 = constants::BYTES_PER_COMMITMENT as u32;
@@ -43,7 +46,13 @@ impl DASContextJs {
   #[napi(constructor)]
   pub fn new() -> Self {
     DASContextJs {
-      inner: Arc::new(DASContext::default()),
+      inner: Arc::new(DASContext::with_threads(
+        &TrustedSetup::default(),
+        1,
+        UsePrecomp::Yes {
+          width: RECOMMENDED_PRECOMP_WIDTH,
+        },
+      )),
     }
   }
 

--- a/cryptography/bls12_381/benches/benchmark.rs
+++ b/cryptography/bls12_381/benches/benchmark.rs
@@ -1,7 +1,7 @@
 use crate_crypto_internal_eth_kzg_bls12_381::{
     batch_inversion,
     ff::Field,
-    fixed_base_msm::FixedBaseMSM,
+    fixed_base_msm::{FixedBaseMSM, UsePrecomp},
     g1_batch_normalize, g2_batch_normalize,
     group::Group,
     lincomb::{g1_lincomb, g1_lincomb_unsafe, g2_lincomb, g2_lincomb_unsafe},
@@ -28,7 +28,7 @@ pub fn fixed_base_msm(c: &mut Criterion) {
         .into_iter()
         .map(|p| p.into())
         .collect();
-    let fbm = FixedBaseMSM::new(generators, 8);
+    let fbm = FixedBaseMSM::new(generators, UsePrecomp::Yes { width: 8 });
     let scalars: Vec<_> = random_scalars(length);
 
     c.bench_function("bls12_381 fixed_base_msm length=64 width=8", |b| {

--- a/cryptography/bls12_381/src/fixed_base_msm.rs
+++ b/cryptography/bls12_381/src/fixed_base_msm.rs
@@ -1,18 +1,57 @@
 use crate::{G1Projective, Scalar};
 use blstrs::{Fp, G1Affine};
 
-/// FixedBasedMSM computes a multi scalar multiplication using pre-computations.
+/// FixedBaseMSMPrecomp computes a multi scalar multiplication using pre-computations.
 ///
 /// It uses batch addition to amortize the cost of adding multiple points together.
 #[derive(Debug)]
-pub struct FixedBaseMSM {
+pub struct FixedBaseMSMPrecomp {
     table: Vec<blst::blst_p1_affine>,
     wbits: usize,
     num_points: usize,
     scratch_space_size: usize,
 }
 
+/// UsePrecomp indicates whether we should use pre-computations to speed up the MSM
+pub enum UsePrecomp {
+    Yes { width: usize },
+    No,
+}
+
+/// FixedBaseMSM computes a multi scalar multiplication where the points are known beforehand.
+///
+/// Since the points are known, one can choose to precompute multiple of the points
+/// in order to reduce the amount of work needed to compute the MSM, at the cost
+/// of memory.
+#[derive(Debug)]
+pub enum FixedBaseMSM {
+    Precomp(FixedBaseMSMPrecomp),
+    NoPrecomp(Vec<G1Affine>),
+}
+
 impl FixedBaseMSM {
+    pub fn new(generators: Vec<G1Affine>, use_precomp: UsePrecomp) -> Self {
+        match use_precomp {
+            UsePrecomp::Yes { width } => {
+                FixedBaseMSM::Precomp(FixedBaseMSMPrecomp::new(generators, width))
+            }
+            UsePrecomp::No => FixedBaseMSM::NoPrecomp(generators),
+        }
+    }
+
+    pub fn msm(&self, scalars: Vec<Scalar>) -> G1Projective {
+        match self {
+            FixedBaseMSM::Precomp(precomp) => precomp.msm(scalars),
+            FixedBaseMSM::NoPrecomp(generators) => {
+                use crate::lincomb::g1_lincomb;
+                g1_lincomb(generators, &scalars)
+                    .expect("number of generators and scalars should be equal")
+            }
+        }
+    }
+}
+
+impl FixedBaseMSMPrecomp {
     pub fn new(generators_affine: Vec<G1Affine>, wbits: usize) -> Self {
         let num_points = generators_affine.len();
         let table_size_bytes =
@@ -33,7 +72,7 @@ impl FixedBaseMSM {
 
         let scratch_space_size = unsafe { blst::blst_p1s_mult_wbits_scratch_sizeof(num_points) };
 
-        FixedBaseMSM {
+        FixedBaseMSMPrecomp {
             table,
             wbits,
             num_points,
@@ -79,7 +118,7 @@ impl FixedBaseMSM {
 
 #[cfg(test)]
 mod tests {
-    use super::FixedBaseMSM;
+    use super::FixedBaseMSMPrecomp;
     use crate::{lincomb::g1_lincomb, G1Projective, Scalar};
     use ff::Field;
     use group::Group;
@@ -97,7 +136,7 @@ mod tests {
 
         let res = g1_lincomb(&generators, &scalars)
             .expect("number of generators and number of scalars is equal");
-        let fbm = FixedBaseMSM::new(generators, 8);
+        let fbm = FixedBaseMSMPrecomp::new(generators, 8);
 
         let result = fbm.msm(scalars);
         assert_eq!(res, result);
@@ -110,7 +149,7 @@ mod tests {
         let generators: Vec<_> = (0..length)
             .map(|_| G1Projective::random(&mut rand::thread_rng()).into())
             .collect();
-        let fbm = FixedBaseMSM::new(generators, 8);
+        let fbm = FixedBaseMSMPrecomp::new(generators, 8);
         for val in fbm.table.into_iter() {
             let is_inf =
                 unsafe { blst::blst_p1_affine_is_inf(&val as *const blst::blst_p1_affine) };

--- a/cryptography/bls12_381/src/fixed_base_msm.rs
+++ b/cryptography/bls12_381/src/fixed_base_msm.rs
@@ -13,6 +13,8 @@ pub struct FixedBaseMSMPrecomp {
 }
 
 /// UsePrecomp indicates whether we should use pre-computations to speed up the MSM
+/// and the level of precomputation to perform.
+#[derive(Debug, Copy, Clone)]
 pub enum UsePrecomp {
     Yes { width: usize },
     No,

--- a/cryptography/kzg_multi_open/benches/benchmark.rs
+++ b/cryptography/kzg_multi_open/benches/benchmark.rs
@@ -1,3 +1,4 @@
+use bls12_381::fixed_base_msm::UsePrecomp;
 use bls12_381::{ff::Field, G1Projective};
 use bls12_381::{g1_batch_normalize, g2_batch_normalize, G2Projective, Scalar};
 use crate_crypto_kzg_multi_open_fk20::Verifier;
@@ -19,6 +20,7 @@ pub fn bench_compute_proof_fk20(c: &mut Criterion) {
         POLYNOMIAL_LEN,
         NUMBER_OF_POINTS_PER_PROOF,
         NUMBER_OF_POINTS_TO_EVALUATE,
+        UsePrecomp::Yes { width: 8 },
     );
 
     let num_proofs = prover.num_proofs();
@@ -48,6 +50,7 @@ pub fn bench_verify_proof_fk20(c: &mut Criterion) {
         POLYNOMIAL_LEN,
         NUMBER_OF_POINTS_PER_PROOF,
         NUMBER_OF_POINTS_TO_EVALUATE,
+        UsePrecomp::Yes { width: 8 },
     );
     let num_proofs = prover.num_proofs();
     let commitment = prover.commit(ProverInput::PolyCoeff(polynomial_4096.clone()));

--- a/cryptography/kzg_multi_open/src/fk20/batch_toeplitz.rs
+++ b/cryptography/kzg_multi_open/src/fk20/batch_toeplitz.rs
@@ -1,5 +1,8 @@
 use crate::fk20::toeplitz::{CirculantMatrix, ToeplitzMatrix};
-use bls12_381::{fixed_base_msm::FixedBaseMSM, g1_batch_normalize, G1Point, G1Projective};
+use bls12_381::{
+    fixed_base_msm::{FixedBaseMSM, UsePrecomp},
+    g1_batch_normalize, G1Point, G1Projective,
+};
 use polynomial::domain::Domain;
 use rayon::prelude::*;
 
@@ -60,7 +63,7 @@ impl BatchToeplitzMatrixVecMul {
         const TABLE_BITS: usize = 8;
         let precomputed_table: Vec<_> = transposed_msm_vectors
             .into_par_iter()
-            .map(|v| FixedBaseMSM::new(v, TABLE_BITS))
+            .map(|v| FixedBaseMSM::new(v, UsePrecomp::Yes { width: TABLE_BITS }))
             .collect();
 
         BatchToeplitzMatrixVecMul {

--- a/cryptography/kzg_multi_open/src/fk20/h_poly.rs
+++ b/cryptography/kzg_multi_open/src/fk20/h_poly.rs
@@ -78,7 +78,7 @@ mod tests {
             prover::FK20Prover,
         },
     };
-    use bls12_381::Scalar;
+    use bls12_381::{fixed_base_msm::UsePrecomp, Scalar};
 
     #[test]
     fn smoke_test_downsample() {
@@ -104,7 +104,7 @@ mod tests {
 
         // Compute the commitment to the h_polynomials using the method noted in the FK20 paper
         //
-        let fk20 = FK20Prover::new(commit_key, 4096, coset_size, 2 * 4096);
+        let fk20 = FK20Prover::new(commit_key, 4096, coset_size, 2 * 4096, UsePrecomp::No);
         let got_comm_h_polys =
             compute_h_poly_commitments(fk20.batch_toeplitz_matrix(), poly, coset_size);
 

--- a/eip7594/benches/benchmark.rs
+++ b/eip7594/benches/benchmark.rs
@@ -37,7 +37,11 @@ pub fn bench_compute_cells_and_kzg_proofs(c: &mut Criterion) {
     let blob = dummy_blob();
 
     for num_threads in THREAD_COUNTS {
-        let ctx = DASContext::with_threads(&trusted_setup, num_threads);
+        let ctx = DASContext::with_threads(
+            &trusted_setup,
+            num_threads,
+            bls12_381::fixed_base_msm::UsePrecomp::Yes { width: 8 },
+        );
         c.bench_function(
             &format!(
                 "computing cells_and_kzg_proofs - NUM_THREADS: {}",
@@ -63,7 +67,11 @@ pub fn bench_recover_cells_and_compute_kzg_proofs(c: &mut Criterion) {
         .collect::<Vec<_>>();
 
     for num_threads in THREAD_COUNTS {
-        let ctx = DASContext::with_threads(&trusted_setup, num_threads);
+        let ctx = DASContext::with_threads(
+            &trusted_setup,
+            num_threads,
+            bls12_381::fixed_base_msm::UsePrecomp::Yes { width: 8 },
+        );
         c.bench_function(
             &format!(
                 "worse-case recover_cells_and_kzg_proofs - NUM_THREADS: {}",
@@ -92,7 +100,11 @@ pub fn bench_verify_cell_kzg_proof_batch(c: &mut Criterion) {
     let proof_refs: Vec<Bytes48Ref> = proofs.iter().map(|proof| proof).collect();
 
     for num_threads in THREAD_COUNTS {
-        let ctx = DASContext::with_threads(&trusted_setup, num_threads);
+        let ctx = DASContext::with_threads(
+            &trusted_setup,
+            num_threads,
+            bls12_381::fixed_base_msm::UsePrecomp::Yes { width: 8 },
+        );
         c.bench_function(
             &format!("verify_cell_kzg_proof_batch - NUM_THREADS: {}", num_threads),
             |b| {
@@ -114,7 +126,11 @@ pub fn bench_init_context(c: &mut Criterion) {
     c.bench_function(&format!("Initialize context"), |b| {
         b.iter(|| {
             let trusted_setup = TrustedSetup::default();
-            DASContext::with_threads(&trusted_setup, NUM_THREADS)
+            DASContext::with_threads(
+                &trusted_setup,
+                NUM_THREADS,
+                bls12_381::fixed_base_msm::UsePrecomp::Yes { width: 8 },
+            )
         })
     });
 }

--- a/eip7594/src/constants.rs
+++ b/eip7594/src/constants.rs
@@ -53,3 +53,9 @@ pub(crate) const BYTES_PER_G1_POINT: usize = 48;
 ///
 /// Note: commitments are G1 elements.
 pub const BYTES_PER_COMMITMENT: usize = BYTES_PER_G1_POINT;
+
+/// The recommended precomputation width to use if UsePrecomp
+/// is set to Yes.
+///
+/// This is based off of heuristics.
+pub const RECOMMENDED_PRECOMP_WIDTH: usize = 8;

--- a/eip7594/src/lib.rs
+++ b/eip7594/src/lib.rs
@@ -87,6 +87,10 @@ impl DASContext {
     pub fn with_threads(
         trusted_setup: &TrustedSetup,
         num_threads: usize,
+        // This parameter indicates whether we should allocate memory
+        // in order to speed up proof creation. Heuristics show that
+        // if pre-computations are desired, one should set the
+        // width value to `8` for optimal storage and performance tradeoffs.
         use_precomp: UsePrecomp,
     ) -> Self {
         let thread_pool = std::sync::Arc::new(

--- a/eip7594/src/lib.rs
+++ b/eip7594/src/lib.rs
@@ -5,6 +5,7 @@ mod serialization;
 mod trusted_setup;
 mod verifier;
 
+pub use bls12_381::fixed_base_msm::UsePrecomp;
 // Exported types
 //
 pub use errors::Error;
@@ -78,12 +79,16 @@ impl Default for DASContext {
     fn default() -> Self {
         let trusted_setup = TrustedSetup::default();
         const DEFAULT_NUM_THREADS: usize = 1;
-        DASContext::with_threads(&trusted_setup, DEFAULT_NUM_THREADS)
+        DASContext::with_threads(&trusted_setup, DEFAULT_NUM_THREADS, UsePrecomp::No)
     }
 }
 
 impl DASContext {
-    pub fn with_threads(trusted_setup: &TrustedSetup, num_threads: usize) -> Self {
+    pub fn with_threads(
+        trusted_setup: &TrustedSetup,
+        num_threads: usize,
+        use_precomp: UsePrecomp,
+    ) -> Self {
         let thread_pool = std::sync::Arc::new(
             rayon::ThreadPoolBuilder::new()
                 .num_threads(num_threads)
@@ -93,7 +98,7 @@ impl DASContext {
 
         DASContext {
             thread_pool,
-            prover_ctx: ProverContext::new(trusted_setup),
+            prover_ctx: ProverContext::new(trusted_setup, use_precomp),
             verifier_ctx: VerifierContext::new(trusted_setup),
         }
     }

--- a/eip7594/src/prover.rs
+++ b/eip7594/src/prover.rs
@@ -1,3 +1,4 @@
+use bls12_381::fixed_base_msm::UsePrecomp;
 use kzg_multi_open::{
     commit_key::CommitKey,
     {Prover, ProverInput},
@@ -26,12 +27,12 @@ pub struct ProverContext {
 impl Default for ProverContext {
     fn default() -> Self {
         let trusted_setup = TrustedSetup::default();
-        Self::new(&trusted_setup)
+        Self::new(&trusted_setup, UsePrecomp::No)
     }
 }
 
 impl ProverContext {
-    pub fn new(trusted_setup: &TrustedSetup) -> Self {
+    pub fn new(trusted_setup: &TrustedSetup, use_precomp: UsePrecomp) -> Self {
         let commit_key = CommitKey::from(trusted_setup);
 
         // The number of points that we will make an opening proof for,
@@ -49,6 +50,7 @@ impl ProverContext {
             FIELD_ELEMENTS_PER_BLOB,
             point_set_size,
             number_of_points_to_open,
+            use_precomp,
         );
 
         ProverContext {


### PR DESCRIPTION
**Breaking change**

Users now need to specify whether they want to use Precomp or not, if calling DasContext::with_threads. To preserve the previous behaviour, one can pass `UsePrecomp::Yes{width:8}`

Its also breaking because the `Default::default` method no longer creates the precomputations. This was changed because the Default::default method was using up 100MB of data, and we want the user to intentionally opt into this.

**Note**

In the future, we may be able to allow the user to specify a memory-limit and we compute the width parameter based off of that, but this seems like a non-goal right now