### PR TITLE
feat!: Add a ThreadCount enum for specifying the number of threads to use

### DIFF
--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -6,6 +6,7 @@ use compute_cells_and_kzg_proofs::_compute_cells_and_kzg_proofs;
 
 mod verify_cells_and_kzg_proofs_batch;
 use rust_eth_kzg::constants::RECOMMENDED_PRECOMP_WIDTH;
+use rust_eth_kzg::ThreadCount;
 use verify_cells_and_kzg_proofs_batch::_verify_cell_kzg_proof_batch;
 
 mod recover_cells_and_kzg_proofs;
@@ -62,7 +63,7 @@ pub extern "C" fn eth_kzg_das_context_new() -> *mut DASContext {
     let ctx = Box::new(DASContext {
         inner: rust_eth_kzg::DASContext::with_threads(
             &rust_eth_kzg::TrustedSetup::default(),
-            1,
+            ThreadCount::Multi(1),
             rust_eth_kzg::UsePrecomp::Yes {
                 width: RECOMMENDED_PRECOMP_WIDTH,
             },

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -8,7 +8,7 @@ use napi_derive::napi;
 
 use rust_eth_kzg::{
   constants::{self, RECOMMENDED_PRECOMP_WIDTH},
-  DASContext, TrustedSetup, UsePrecomp,
+  DASContext, ThreadCount, TrustedSetup, UsePrecomp,
 };
 
 #[napi]
@@ -48,7 +48,7 @@ impl DASContextJs {
     DASContextJs {
       inner: Arc::new(DASContext::with_threads(
         &TrustedSetup::default(),
-        1,
+        ThreadCount::Single,
         UsePrecomp::Yes {
           width: RECOMMENDED_PRECOMP_WIDTH,
         },

--- a/eip7594/benches/benchmark.rs
+++ b/eip7594/benches/benchmark.rs
@@ -2,7 +2,8 @@ use bls12_381::Scalar;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rust_eth_kzg::{
     constants::{BYTES_PER_BLOB, CELLS_PER_EXT_BLOB},
-    Bytes48Ref, Cell, CellIndex, CellRef, DASContext, KZGCommitment, KZGProof, TrustedSetup,
+    Bytes48Ref, Cell, CellIndex, CellRef, DASContext, KZGCommitment, KZGProof, ThreadCount,
+    TrustedSetup,
 };
 
 const POLYNOMIAL_LEN: usize = 4096;
@@ -29,7 +30,13 @@ fn dummy_commitment_cells_and_proofs() -> (
     (commitment, ctx.compute_cells_and_kzg_proofs(&blob).unwrap())
 }
 
-const THREAD_COUNTS: [usize; 5] = [1, 4, 8, 16, 32];
+const THREAD_COUNTS: [ThreadCount; 5] = [
+    ThreadCount::Single,
+    ThreadCount::Multi(4),
+    ThreadCount::Multi(8),
+    ThreadCount::Multi(16),
+    ThreadCount::Multi(32),
+];
 
 pub fn bench_compute_cells_and_kzg_proofs(c: &mut Criterion) {
     let trusted_setup = TrustedSetup::default();
@@ -40,7 +47,7 @@ pub fn bench_compute_cells_and_kzg_proofs(c: &mut Criterion) {
         let ctx = DASContext::with_threads(&trusted_setup, num_threads);
         c.bench_function(
             &format!(
-                "computing cells_and_kzg_proofs - NUM_THREADS: {}",
+                "computing cells_and_kzg_proofs - NUM_THREADS: {:?}",
                 num_threads
             ),
             |b| b.iter(|| ctx.compute_cells_and_kzg_proofs(&blob)),
@@ -66,7 +73,7 @@ pub fn bench_recover_cells_and_compute_kzg_proofs(c: &mut Criterion) {
         let ctx = DASContext::with_threads(&trusted_setup, num_threads);
         c.bench_function(
             &format!(
-                "worse-case recover_cells_and_kzg_proofs - NUM_THREADS: {}",
+                "worse-case recover_cells_and_kzg_proofs - NUM_THREADS: {:?}",
                 num_threads
             ),
             |b| {
@@ -94,7 +101,10 @@ pub fn bench_verify_cell_kzg_proof_batch(c: &mut Criterion) {
     for num_threads in THREAD_COUNTS {
         let ctx = DASContext::with_threads(&trusted_setup, num_threads);
         c.bench_function(
-            &format!("verify_cell_kzg_proof_batch - NUM_THREADS: {}", num_threads),
+            &format!(
+                "verify_cell_kzg_proof_batch - NUM_THREADS: {:?}",
+                num_threads
+            ),
             |b| {
                 b.iter(|| {
                     ctx.verify_cell_kzg_proof_batch(
@@ -110,7 +120,7 @@ pub fn bench_verify_cell_kzg_proof_batch(c: &mut Criterion) {
 }
 
 pub fn bench_init_context(c: &mut Criterion) {
-    const NUM_THREADS: usize = 1;
+    const NUM_THREADS: ThreadCount = ThreadCount::Single;
     c.bench_function(&format!("Initialize context"), |b| {
         b.iter(|| {
             let trusted_setup = TrustedSetup::default();

--- a/eip7594/src/lib.rs
+++ b/eip7594/src/lib.rs
@@ -58,7 +58,7 @@ use rayon::ThreadPool;
 use std::sync::Arc;
 use verifier::VerifierContext;
 
-/// Threads indicates whether we want to use a single thread or multiple threads
+/// ThreadCount indicates whether we want to use a single thread or multiple threads
 #[derive(Debug, Copy, Clone)]
 pub enum ThreadCount {
     /// Initializes the threadpool with a single thread


### PR DESCRIPTION
**Breaking change**

Instead of specifying the number of threads with a usize like `5`, users can now specify it by doing `ThreadCount::Multi(5)`