### PR TITLE
chore: Codify subtle version that rust-eth-kzg works with as >=2.5.0

### DIFF
--- a/cryptography/bls12_381/Cargo.toml
+++ b/cryptography/bls12_381/Cargo.toml
@@ -21,6 +21,13 @@ ff = "0.13.0"
 group = "0.13"
 pairing = { version = "0.23" }
 
+# Transitively, we depend on subtle version >=2.5.0
+# Adding the restrictions here codify it in rust-eth-kzg.
+# 
+# See https://github.com/crate-crypto/rust-eth-kzg/issues/235 for more info 
+# as to why we need to pull it in here, even though it is not used directly.
+subtle = { version = ">=2.5.0, <3.0" }
+
 [dev-dependencies]
 criterion = "0.5.1"
 rand = "0.8.4"


### PR DESCRIPTION
Closes #235 