### PR TITLE
chore: Make batch_inverse single threaded

### DIFF
--- a/cryptography/bls12_381/Cargo.toml
+++ b/cryptography/bls12_381/Cargo.toml
@@ -11,7 +11,6 @@ repository = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rayon = { workspace = true }
 
 blst = { version = "0.3", default-features = false }
 

--- a/cryptography/bls12_381/src/batch_inversion.rs
+++ b/cryptography/bls12_381/src/batch_inversion.rs
@@ -1,32 +1,5 @@
-use rayon::prelude::*;
-
 /// Given a vector of field elements {v_i}, compute the vector {v_i^(-1)}
-//
-/// Panics: If any of the elements are zero
-pub fn batch_inverse<F: ff::Field>(elements: &mut [F]) {
-    batch_inversion(elements)
-}
-
-/// Given a vector of field elements {v_i}, compute the vector {v_i^(-1)}
-///
-// Taken and modified from arkworks codebase
-fn batch_inversion<F: ff::Field>(v: &mut [F]) {
-    // Divide the vector v evenly between all available cores
-    let min_elements_per_thread = 1;
-    let num_cpus_available = rayon::current_num_threads();
-    let num_elems = v.len();
-    let num_elem_per_thread =
-        std::cmp::max(num_elems / num_cpus_available, min_elements_per_thread);
-
-    // Batch invert in parallel, without copying the vector
-    v.par_chunks_mut(num_elem_per_thread).for_each(|chunk| {
-        serial_batch_inversion(chunk);
-    });
-}
-
-/// Given a vector of field elements {v_i}, compute the vector {coeff * v_i^(-1)}
-/// This method is explicitly single core.
-fn serial_batch_inversion<F: ff::Field>(v: &mut [F]) {
+pub fn batch_inverse<F: ff::Field>(v: &mut [F]) {
     // Montgomery’s Trick and Fast Implementation of Masked AES
     // Genelle, Prouff and Quisquater
     // Section 3.2


### PR DESCRIPTION
There was no measurable difference between single and multithreaded for our usecases