### PR TITLE
chore: enable required features for benchmarks

### DIFF
--- a/eip7594/Cargo.toml
+++ b/eip7594/Cargo.toml
@@ -32,4 +32,4 @@ serde_yaml = "0.9.34"
 [[bench]]
 name = "benchmark"
 harness = false
-# required-features = ["multithreaded"]
+required-features = ["multithreaded"]


### PR DESCRIPTION
The benchmarks as written currently require the multithreaded feature flag, so we specify this in Cargo.toml.

If not specified, then it will just give an error when compiling, due to some features being under the multithreaded feature flag.