### PR TITLE
chore: replace Scalar::from(0u64) and Scalar::from(1u64)

### DIFF
--- a/cryptography/erasure_codes/src/reed_solomon.rs
+++ b/cryptography/erasure_codes/src/reed_solomon.rs
@@ -450,7 +450,7 @@ mod tests {
             // zero out `num_erasures` amount of evaluations to simulate erasures
             let mut missing_indices = Vec::new();
             for index in 0..num_erasures {
-                codewords_with_erasures[index] = Scalar::from(0);
+                codewords_with_erasures[index] = Scalar::ZERO;
                 missing_indices.push(index);
             }
 
@@ -490,7 +490,7 @@ mod tests {
             let mut missing_block_indices = Vec::new();
             for index in 0..num_block_erasures {
                 for block in &mut blocks {
-                    block[index] = Scalar::from(0)
+                    block[index] = Scalar::ZERO
                 }
                 missing_block_indices.push(index);
             }

--- a/cryptography/kzg_multi_open/benches/benchmark.rs
+++ b/cryptography/kzg_multi_open/benches/benchmark.rs
@@ -101,7 +101,7 @@ pub fn create_insecure_commit_opening_keys() -> (CommitKey, OpeningKey) {
     let g1_gen = G1Projective::generator();
 
     let mut g1_points = Vec::new();
-    let secret = -Scalar::from(1 as u64);
+    let secret = -Scalar::ONE;
     let mut current_secret_pow = Scalar::ONE;
     for _ in 0..num_coefficients_in_polynomial {
         g1_points.push(g1_gen * current_secret_pow);
@@ -112,7 +112,7 @@ pub fn create_insecure_commit_opening_keys() -> (CommitKey, OpeningKey) {
     let ck = CommitKey::new(g1_points.clone());
 
     let mut g2_points = Vec::new();
-    let secret = -Scalar::from(1 as u64);
+    let secret = -Scalar::ONE;
     let mut current_secret_pow = Scalar::ONE;
     let g2_gen = G2Projective::generator();
     // The setup needs 65 g1 elements for the opening key, in order

--- a/cryptography/kzg_multi_open/src/fk20/cosets.rs
+++ b/cryptography/kzg_multi_open/src/fk20/cosets.rs
@@ -1,4 +1,4 @@
-use bls12_381::Scalar;
+use bls12_381::{ff::Field, Scalar};
 use polynomial::domain::Domain;
 
 /// Reverses the least significant `bits` of the given number `n`.
@@ -113,7 +113,7 @@ pub fn recover_evaluations_in_domain_order(
         return None;
     }
 
-    let mut elements = vec![Scalar::from(0u64); domain_size];
+    let mut elements = vec![Scalar::ZERO; domain_size];
 
     // Check that each coset has the same size
     let coset_len = coset_evaluations[0].len();

--- a/cryptography/kzg_multi_open/src/fk20/h_poly.rs
+++ b/cryptography/kzg_multi_open/src/fk20/h_poly.rs
@@ -1,5 +1,5 @@
 use crate::fk20::toeplitz::ToeplitzMatrix;
-use bls12_381::{G1Projective, Scalar};
+use bls12_381::{ff::Field, G1Projective, Scalar};
 use polynomial::monomial::PolyCoeff;
 
 use super::batch_toeplitz::BatchToeplitzMatrixVecMul;
@@ -47,7 +47,7 @@ pub(crate) fn compute_h_poly_commitments(
     let mut matrices = Vec::with_capacity(toeplitz_rows.len());
     // We want to do `coset_size` toeplitz matrix multiplications
     for row in toeplitz_rows.into_iter() {
-        let mut toeplitz_column = vec![Scalar::from(0u64); row.len()];
+        let mut toeplitz_column = vec![Scalar::ZERO; row.len()];
         toeplitz_column[0] = row[0];
 
         matrices.push(ToeplitzMatrix::new(row, toeplitz_column));

--- a/cryptography/kzg_multi_open/src/fk20/toeplitz.rs
+++ b/cryptography/kzg_multi_open/src/fk20/toeplitz.rs
@@ -207,6 +207,8 @@ struct DenseMatrix {
 impl DenseMatrix {
     /// Converts a `ToeplitzMatrix` into a `DenseMatrix`
     fn from_toeplitz(toeplitz: ToeplitzMatrix) -> DenseMatrix {
+        use bls12_381::ff::Field;
+
         let rows = toeplitz.col.len();
         let cols = toeplitz.row.len();
         let mut matrix = vec![vec![Scalar::ZERO; toeplitz.col.len()]; toeplitz.row.len()];

--- a/cryptography/kzg_multi_open/src/fk20/toeplitz.rs
+++ b/cryptography/kzg_multi_open/src/fk20/toeplitz.rs
@@ -209,7 +209,7 @@ impl DenseMatrix {
     fn from_toeplitz(toeplitz: ToeplitzMatrix) -> DenseMatrix {
         let rows = toeplitz.col.len();
         let cols = toeplitz.row.len();
-        let mut matrix = vec![vec![Scalar::from(0u64); toeplitz.col.len()]; toeplitz.row.len()];
+        let mut matrix = vec![vec![Scalar::ZERO; toeplitz.col.len()]; toeplitz.row.len()];
 
         for i in 0..rows {
             for j in 0..cols {

--- a/cryptography/kzg_multi_open/src/fk20/verifier.rs
+++ b/cryptography/kzg_multi_open/src/fk20/verifier.rs
@@ -177,7 +177,7 @@ impl FK20Verifier {
         // One can view this as trading a scalar multiplication for a field addition.
         //
         // The extra field additions are being calculated in the for loop below.
-        let mut weights = vec![Scalar::from(0); num_unique_commitments];
+        let mut weights = vec![Scalar::ZERO; num_unique_commitments];
         for (commitment_index, r_power) in commitment_indices.iter().zip(r_powers.iter()) {
             weights[*commitment_index as usize] += r_power;
         }

--- a/cryptography/kzg_multi_open/src/lib.rs
+++ b/cryptography/kzg_multi_open/src/lib.rs
@@ -28,7 +28,7 @@ pub(crate) fn create_insecure_commit_opening_keys(
     let g1_gen = G1Projective::generator();
 
     let mut g1_points = Vec::new();
-    let secret = -Scalar::from(1 as u64);
+    let secret = -Scalar::ONE;
     let mut current_secret_pow = Scalar::ONE;
     for _ in 0..num_coefficients_in_polynomial {
         g1_points.push(g1_gen * current_secret_pow);
@@ -39,7 +39,7 @@ pub(crate) fn create_insecure_commit_opening_keys(
     let ck = CommitKey::new(g1_points.clone());
 
     let mut g2_points = Vec::new();
-    let secret = -Scalar::from(1 as u64);
+    let secret = -Scalar::ONE;
     let mut current_secret_pow = Scalar::ONE;
     let g2_gen = G2Projective::generator();
     // The setup needs 65 g1 elements for the opening key, in order

--- a/cryptography/kzg_multi_open/src/naive.rs
+++ b/cryptography/kzg_multi_open/src/naive.rs
@@ -1,5 +1,5 @@
 use crate::{commit_key::CommitKey, opening_key::OpeningKey};
-use bls12_381::{multi_pairings, G1Point, G1Projective, G2Point, G2Prepared, Scalar};
+use bls12_381::{ff::Field, multi_pairings, G1Point, G1Projective, G2Point, G2Prepared, Scalar};
 use polynomial::monomial::{lagrange_interpolate, poly_eval, poly_sub, vanishing_poly, PolyCoeff};
 
 /// This modules contains code to create and verify opening proofs in a naive way.

--- a/cryptography/kzg_multi_open/src/naive.rs
+++ b/cryptography/kzg_multi_open/src/naive.rs
@@ -67,7 +67,7 @@ fn _compute_multi_opening_naive(
     // Divides `self` by x-z using Ruffinis rule
     fn divide_by_linear(poly: &[Scalar], z: Scalar) -> Vec<Scalar> {
         let mut quotient: Vec<Scalar> = Vec::with_capacity(poly.len());
-        let mut k = Scalar::from(0u64);
+        let mut k = Scalar::ZERO;
 
         for coeff in poly.iter().rev() {
             let t = *coeff + k;

--- a/cryptography/polynomial/src/domain.rs
+++ b/cryptography/polynomial/src/domain.rs
@@ -390,7 +390,7 @@ mod tests {
         }
         fn powers_of(scalar: &Scalar, max_degree: usize) -> Vec<Scalar> {
             let mut powers = Vec::new();
-            powers.push(Scalar::from(1u64));
+            powers.push(Scalar::ONE);
             for i in 1..=max_degree {
                 powers.push(powers[i - 1] * scalar);
             }

--- a/cryptography/polynomial/src/monomial.rs
+++ b/cryptography/polynomial/src/monomial.rs
@@ -42,7 +42,7 @@ pub fn poly_sub(a: PolyCoeff, b: PolyCoeff) -> PolyCoeff {
 /// Given a polynomial `f(x)` and a scalar `z`. This method will compute
 /// the result of `f(z)` and return the result.
 pub fn poly_eval(poly: &PolyCoeff, value: &Scalar) -> Scalar {
-    let mut result = Scalar::from(0u64);
+    let mut result = Scalar::ZERO;
     for coeff in poly.iter().rev() {
         result = result * value + coeff;
     }
@@ -66,9 +66,9 @@ pub fn poly_mul(a: PolyCoeff, b: PolyCoeff) -> PolyCoeff {
 ///
 /// Example: vanishing_poly([1, 2, 3]) = (x - 1)(x - 2)(x - 3)
 pub fn vanishing_poly(roots: &[Scalar]) -> PolyCoeff {
-    let mut poly = vec![Scalar::from(1u64)];
+    let mut poly = vec![Scalar::ONE];
     for root in roots {
-        poly = poly_mul(poly, vec![-root, Scalar::from(1u64)]);
+        poly = poly_mul(poly, vec![-root, Scalar::ONE]);
     }
     poly
 }
@@ -89,13 +89,13 @@ pub fn lagrange_interpolate(points: &[(Scalar, Scalar)]) -> Option<Vec<Scalar>> 
         max_degree_plus_one >= 2,
         "should interpolate for degree >= 1"
     );
-    let mut coeffs = vec![Scalar::from(0u64); max_degree_plus_one];
+    let mut coeffs = vec![Scalar::ZERO; max_degree_plus_one];
     // external iterator
     for (k, p_k) in points.iter().enumerate() {
         let (x_k, y_k) = p_k;
         // coeffs from 0 to max_degree - 1
-        let mut contribution = vec![Scalar::from(0u64); max_degree_plus_one];
-        let mut denominator = Scalar::from(1u64);
+        let mut contribution = vec![Scalar::ZERO; max_degree_plus_one];
+        let mut denominator = Scalar::ONE;
         let mut max_contribution_degree = 0;
         // internal iterator
         for (j, p_j) in points.iter().enumerate() {
@@ -127,7 +127,7 @@ pub fn lagrange_interpolate(points: &[(Scalar, Scalar)]) -> Option<Vec<Scalar>> 
                     })
                     .collect();
 
-                contribution.insert(0, Scalar::from(0u64));
+                contribution.insert(0, Scalar::ZERO);
                 contribution.truncate(max_degree_plus_one);
 
                 assert_eq!(mul_by_minus_x_j.len(), max_degree_plus_one);
@@ -161,7 +161,7 @@ mod tests {
     use bls12_381::ff::Field;
 
     fn naive_poly_eval(poly: &PolyCoeff, value: &Scalar) -> Scalar {
-        let mut result = Scalar::from(0u64);
+        let mut result = Scalar::ZERO;
         for (i, coeff) in poly.iter().enumerate() {
             result += coeff * value.pow_vartime(&[i as u64]);
         }
@@ -241,7 +241,7 @@ mod tests {
 
         // Check that this polynomial evaluates to zero on the roots
         for root in roots.iter() {
-            assert_eq!(poly_eval(&poly, &root), Scalar::from(0u64));
+            assert_eq!(poly_eval(&poly, &root), Scalar::ZERO);
         }
     }
 


### PR DESCRIPTION
closes #264 

There are some places where it is left in (mainly tests) just due to the code needing to do things like : `vec![Scalar::from(0), Scalar::from(1), Scalar::from(2)]`

The main downside of Scalar::ONE and Scalar::ZERO is that they require another import but I think its fine for the most part since we usually already import ff::Field for other methods