### PR TITLE
chore: Fix windows build

### DIFF
--- a/.github/scripts/install_libnode_dll_windows.sh
+++ b/.github/scripts/install_libnode_dll_windows.sh
@@ -1,31 +1,6 @@
 #!/bin/bash
 
-# Check if required environment variables are set
-if [ -z "$RUNNER_TOOL_CACHE" ] || [ -z "$NODE_VERSION" ]; then
-    echo "Error: RUNNER_TOOL_CACHE and NODE_VERSION must be set"
-    exit 1
-fi
-
-# Set libnode version
-LIBNODE_VERSION="v23.0.0"
-
-echo "Downloading libnode..."
-curl -L -o libnode.zip "https://github.com/metacall/libnode/releases/download/${LIBNODE_VERSION}/libnode-amd64-windows.zip"
-
-echo "Extracting libnode..."
-unzip libnode.zip
-
-NODE_DIR="$RUNNER_TOOL_CACHE/node/$NODE_VERSION/x64"
-echo "Creating directory if not exists..."
-mkdir -p "$NODE_DIR"
-
-echo "Moving libnode.dll to Node installation directory..."
-cp libnode.dll "$NODE_DIR/"
-
-echo "Verify file was copied:"
-ls -la "$NODE_DIR/libnode.dll"
-
-# Set environment variable
-echo "LIBNODE_PATH=$NODE_DIR" >> $GITHUB_ENV
-
-echo "Setup completed successfully"
+curl -L -o libnode.zip "https://github.com/metacall/libnode/releases/download/v23.0.0/libnode-amd64-windows.zip"
+unzip libnode.zip libnode.dll
+pwd_output=$(pwd)
+echo "LIBNODE_PATH=$pwd_output" >> $GITHUB_ENV

--- a/.github/scripts/install_libnode_dll_windows.sh
+++ b/.github/scripts/install_libnode_dll_windows.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Check if required environment variables are set
+if [ -z "$RUNNER_TOOL_CACHE" ] || [ -z "$NODE_VERSION" ]; then
+    echo "Error: RUNNER_TOOL_CACHE and NODE_VERSION must be set"
+    exit 1
+fi
+
+# Set libnode version
+LIBNODE_VERSION="v23.0.0"
+
+echo "Downloading libnode..."
+curl -L -o libnode.zip "https://github.com/metacall/libnode/releases/download/${LIBNODE_VERSION}/libnode-amd64-windows.zip"
+
+echo "Extracting libnode..."
+unzip libnode.zip
+
+NODE_DIR="$RUNNER_TOOL_CACHE/node/$NODE_VERSION/x64"
+echo "Creating directory if not exists..."
+mkdir -p "$NODE_DIR"
+
+echo "Moving libnode.dll to Node installation directory..."
+cp libnode.dll "$NODE_DIR/"
+
+echo "Verify file was copied:"
+ls -la "$NODE_DIR/libnode.dll"
+
+# Set environment variable
+echo "LIBNODE_PATH=$NODE_DIR" >> $GITHUB_ENV
+
+echo "Setup completed successfully"

--- a/.github/scripts/install_libnode_dll_windows.sh
+++ b/.github/scripts/install_libnode_dll_windows.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# TODO: napi-build requires libnode.dll to be present on the system.
+# Most builds on nodejs do not come with libnode.dll, instead they package
+# everything in one binary. We download the libnode.dll file from the below releases
+# for nodeJs 23.0.0. In the future, we might want to compile from nodeJs source itself and
+# also only make this trigger on the compilation for the node bindings.
+
 curl -L -o libnode.zip "https://github.com/metacall/libnode/releases/download/v23.0.0/libnode-amd64-windows.zip"
 unzip libnode.zip libnode.dll
 pwd_output=$(pwd)

--- a/.github/workflows/release-csharp-bindings.yml
+++ b/.github/workflows/release-csharp-bindings.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Install libnode
         if: matrix.os == 'windows-latest'
-        run: ./scripts/install_libnode_dll_windows.sh golang
+        run: ./scripts/install_libnode_dll_windows.sh
         shell: bash
 
       - name: Run compile script

--- a/.github/workflows/release-csharp-bindings.yml
+++ b/.github/workflows/release-csharp-bindings.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Install libnode
         if: matrix.os == 'windows-latest'
-        run: ./scripts/install_libnode_dll_windows.sh
+        run: .github/scripts/install_libnode_dll_windows.sh
         shell: bash
 
       - name: Run compile script

--- a/.github/workflows/release-csharp-bindings.yml
+++ b/.github/workflows/release-csharp-bindings.yml
@@ -60,6 +60,17 @@ jobs:
           version: 0.10.1
       - name: Install cargo-zigbuild
         run: cargo binstall --no-confirm cargo-zigbuild
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '23.0.0'
+
+      - name: Install libnode
+        if: matrix.os == 'windows-latest'
+        run: ./scripts/install_libnode_dll_windows.sh golang
+        shell: bash
+
       - name: Run compile script
         run: |
           chmod +x .github/scripts/compile_all_targets_c_sharp_new.sh

--- a/.github/workflows/release-java-bindings.yml
+++ b/.github/workflows/release-java-bindings.yml
@@ -60,6 +60,16 @@ jobs:
           version: 0.10.1
       - name: Install cargo-zigbuild
         run: cargo binstall --no-confirm cargo-zigbuild
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '23.0.0'
+      - name: Install libnode
+        if: matrix.os == 'windows-latest'
+        run: ./scripts/install_libnode_dll_windows.sh golang
+        shell: bash
+
       - name: Run compile script
         run: |
           chmod +x .github/scripts/compile_all_targets_java.sh

--- a/.github/workflows/release-java-bindings.yml
+++ b/.github/workflows/release-java-bindings.yml
@@ -67,7 +67,7 @@ jobs:
           node-version: '23.0.0'
       - name: Install libnode
         if: matrix.os == 'windows-latest'
-        run: ./scripts/install_libnode_dll_windows.sh golang
+        run: ./scripts/install_libnode_dll_windows.sh
         shell: bash
 
       - name: Run compile script

--- a/.github/workflows/release-java-bindings.yml
+++ b/.github/workflows/release-java-bindings.yml
@@ -67,7 +67,7 @@ jobs:
           node-version: '23.0.0'
       - name: Install libnode
         if: matrix.os == 'windows-latest'
-        run: ./scripts/install_libnode_dll_windows.sh
+        run: .github/scripts/install_libnode_dll_windows.sh
         shell: bash
 
       - name: Run compile script

--- a/.github/workflows/release-rust-crates.yml
+++ b/.github/workflows/release-rust-crates.yml
@@ -58,12 +58,14 @@ jobs:
         with:
           node-version: '18'
 
-      - name: List Node directory (Windows)
+      - name: Find node dlls (Windows)
         if: matrix.os == 'windows-latest'
         shell: bash
         run: |
-          echo "Listing Node directory contents:"
-          ls -la "C:\hostedtoolcache\windows\node\18.20.6\x64"
+          echo "Checking System32:"
+          ls -la /c/Windows/System32/*node*dll 2>/dev/null || echo "Not found in System32"
+          echo -e "\nChecking Windows directory:"
+          ls -la /c/Windows/*node*dll 2>/dev/null || echo "Not found in Windows"
 
       - name: Build
         run: RUST_BACKTRACE=full cargo build --target ${{ matrix.target }} --verbose

--- a/.github/workflows/release-rust-crates.yml
+++ b/.github/workflows/release-rust-crates.yml
@@ -53,6 +53,11 @@ jobs:
           toolchain: 1.80.0
           target: ${{ matrix.target }}
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
       - name: Build
         run: cargo build --target ${{ matrix.target }} --verbose
         

--- a/.github/workflows/release-rust-crates.yml
+++ b/.github/workflows/release-rust-crates.yml
@@ -58,22 +58,11 @@ jobs:
         with:
           node-version: '23.0.0'
 
-      - name: Setup libnode (Windows)
+      - name: Install libnode
         if: matrix.os == 'windows-latest'
+        run: ./scripts/install_libnode_dll_windows.sh golang
         shell: bash
-        run: |
-          echo "Downloading libnode..."
-          curl -L -o libnode.zip https://github.com/metacall/libnode/releases/download/v23.0.0/libnode-amd64-windows.zip
-          echo "Extracting libnode..."
-          unzip libnode.zip
-          NODE_DIR="$RUNNER_TOOL_CACHE/node/$NODE_VERSION/x64"
-          echo "Creating directory if not exists..."
-          mkdir -p "$NODE_DIR"
-          echo "Moving libnode.dll to Node installation directory..."
-          cp libnode.dll "$NODE_DIR/"
-          echo "Verify file was copied:"
-          ls -la "$NODE_DIR/libnode.dll"
-          echo "LIBNODE_PATH=$NODE_DIR" >> $GITHUB_ENV
+
       - name: Build
         run: RUST_BACKTRACE=full cargo build --target ${{ matrix.target }} --verbose
         shell: bash

--- a/.github/workflows/release-rust-crates.yml
+++ b/.github/workflows/release-rust-crates.yml
@@ -56,7 +56,14 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '18'
+
+      - name: List Node directory (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: |
+          echo "Listing Node directory contents:"
+          ls -la "$RUNNER_TOOL_CACHE/node/$NODE_VERSION/x64"
 
       - name: Build
         run: RUST_BACKTRACE=full cargo build --target ${{ matrix.target }} --verbose

--- a/.github/workflows/release-rust-crates.yml
+++ b/.github/workflows/release-rust-crates.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: 'The reference (branch/tag/commit) to checkout'
+        description: 'The reference (branch/tag/commit) to checkout '
         required: false
       release-type:
         type: choice

--- a/.github/workflows/release-rust-crates.yml
+++ b/.github/workflows/release-rust-crates.yml
@@ -66,11 +66,12 @@ jobs:
           curl -L -o libnode.zip https://github.com/metacall/libnode/releases/download/v23.0.0/libnode-amd64-windows.zip
           echo "Extracting libnode..."
           unzip libnode.zip
-          echo "Checking directory structure:"
-          ls -R
           echo "Moving libnode.dll to Node installation directory..."
           cp libnode.dll "$RUNNER_TOOL_CACHE/node/$NODE_VERSION/x64/"
+          echo "Verify file was copied:"
+          ls -la "$RUNNER_TOOL_CACHE/node/$NODE_VERSION/x64/libnode.dll"
           echo "LIBNODE_PATH=$RUNNER_TOOL_CACHE/node/$NODE_VERSION/x64" >> $GITHUB_ENV
+
       - name: Build
         run: RUST_BACKTRACE=full cargo build --target ${{ matrix.target }} --verbose
         shell: bash

--- a/.github/workflows/release-rust-crates.yml
+++ b/.github/workflows/release-rust-crates.yml
@@ -56,14 +56,14 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '23.0.0'
 
       - name: List Node directory (Windows)
         if: matrix.os == 'windows-latest'
         shell: bash
         run: |
           echo "Listing Node directory contents:"
-          ls -la "C:\hostedtoolcache\windows\node\18.20.6"
+          ls -la "C:\hostedtoolcache\windows\node\23.0.0"
 
       - name: Build
         run: RUST_BACKTRACE=full cargo build --target ${{ matrix.target }} --verbose

--- a/.github/workflows/release-rust-crates.yml
+++ b/.github/workflows/release-rust-crates.yml
@@ -58,16 +58,12 @@ jobs:
         with:
           node-version: '18'
 
-      - name: Search for node dlls (Windows)
+      - name: List Node directory (Windows)
         if: matrix.os == 'windows-latest'
         shell: bash
         run: |
-          echo "Searching for node dlls in Program Files:"
-          find /c/Program\ Files -name "*node*.dll" 2>/dev/null || echo "Not found in Program Files"
-          echo -e "\nSearching in npm cache:"
-          find /c/Users/runneradmin/AppData/Local/npm-cache -name "*node*.dll" 2>/dev/null || echo "Not found in npm cache"
-          echo -e "\nSearching in Node installation:"
-          find /c/hostedtoolcache/windows/node -name "*node*.dll" 2>/dev/null || echo "Not found in Node installation"
+          echo "Listing Node directory contents:"
+          ls -la "C:\hostedtoolcache\windows\node\18.20.6"
 
       - name: Build
         run: RUST_BACKTRACE=full cargo build --target ${{ matrix.target }} --verbose

--- a/.github/workflows/release-rust-crates.yml
+++ b/.github/workflows/release-rust-crates.yml
@@ -66,10 +66,11 @@ jobs:
           curl -L -o libnode.zip https://github.com/metacall/libnode/releases/download/v23.0.0/libnode-amd64-windows.zip
           echo "Extracting libnode..."
           unzip libnode.zip
+          echo "Checking directory structure:"
+          ls -R
           echo "Moving libnode.dll to Node installation directory..."
-          cp libnode-amd64-windows/libnode.dll "$RUNNER_TOOL_CACHE/node/$NODE_VERSION/x64/"
+          cp libnode.dll "$RUNNER_TOOL_CACHE/node/$NODE_VERSION/x64/"
           echo "LIBNODE_PATH=$RUNNER_TOOL_CACHE/node/$NODE_VERSION/x64" >> $GITHUB_ENV
-
       - name: Build
         run: RUST_BACKTRACE=full cargo build --target ${{ matrix.target }} --verbose
         shell: bash

--- a/.github/workflows/release-rust-crates.yml
+++ b/.github/workflows/release-rust-crates.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
 
       - name: Build
         run: cargo build --target ${{ matrix.target }} --verbose

--- a/.github/workflows/release-rust-crates.yml
+++ b/.github/workflows/release-rust-crates.yml
@@ -66,12 +66,14 @@ jobs:
           curl -L -o libnode.zip https://github.com/metacall/libnode/releases/download/v23.0.0/libnode-amd64-windows.zip
           echo "Extracting libnode..."
           unzip libnode.zip
+          NODE_DIR="$RUNNER_TOOL_CACHE/node/$NODE_VERSION/x64"
+          echo "Creating directory if not exists..."
+          mkdir -p "$NODE_DIR"
           echo "Moving libnode.dll to Node installation directory..."
-          cp libnode.dll "$RUNNER_TOOL_CACHE/node/$NODE_VERSION/x64/"
+          cp libnode.dll "$NODE_DIR/"
           echo "Verify file was copied:"
-          ls -la "$RUNNER_TOOL_CACHE/node/$NODE_VERSION/x64/libnode.dll"
-          echo "LIBNODE_PATH=$RUNNER_TOOL_CACHE/node/$NODE_VERSION/x64" >> $GITHUB_ENV
-
+          ls -la "$NODE_DIR/libnode.dll"
+          echo "LIBNODE_PATH=$NODE_DIR" >> $GITHUB_ENV
       - name: Build
         run: RUST_BACKTRACE=full cargo build --target ${{ matrix.target }} --verbose
         shell: bash

--- a/.github/workflows/release-rust-crates.yml
+++ b/.github/workflows/release-rust-crates.yml
@@ -54,7 +54,7 @@ jobs:
           target: ${{ matrix.target }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
 

--- a/.github/workflows/release-rust-crates.yml
+++ b/.github/workflows/release-rust-crates.yml
@@ -63,7 +63,7 @@ jobs:
         shell: bash
         run: |
           echo "Listing Node directory contents:"
-          ls -la "$RUNNER_TOOL_CACHE/node/$NODE_VERSION/x64"
+          ls -la "C:\hostedtoolcache\windows\node\18.20.6\x64"
 
       - name: Build
         run: RUST_BACKTRACE=full cargo build --target ${{ matrix.target }} --verbose

--- a/.github/workflows/release-rust-crates.yml
+++ b/.github/workflows/release-rust-crates.yml
@@ -60,6 +60,7 @@ jobs:
 
       - name: Build
         run: RUST_BACKTRACE=full cargo build --target ${{ matrix.target }} --verbose
+        shell: bash
         
       - name: Run tests
         run: RUST_BACKTRACE=1 cargo test --target ${{ matrix.target }}

--- a/.github/workflows/release-rust-crates.yml
+++ b/.github/workflows/release-rust-crates.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Install libnode
         if: matrix.os == 'windows-latest'
-        run: ./scripts/install_libnode_dll_windows.sh golang
+        run: ./scripts/install_libnode_dll_windows.sh
         shell: bash
 
       - name: Build

--- a/.github/workflows/release-rust-crates.yml
+++ b/.github/workflows/release-rust-crates.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Install libnode
         if: matrix.os == 'windows-latest'
-        run: ./scripts/install_libnode_dll_windows.sh
+        run: .github/scripts/install_libnode_dll_windows.sh
         shell: bash
 
       - name: Build

--- a/.github/workflows/release-rust-crates.yml
+++ b/.github/workflows/release-rust-crates.yml
@@ -59,7 +59,7 @@ jobs:
           node-version: '20'
 
       - name: Build
-        run: cargo build --target ${{ matrix.target }} --verbose
+        run: RUST_BACKTRACE=full cargo build --target ${{ matrix.target }} --verbose
         
       - name: Run tests
         run: RUST_BACKTRACE=1 cargo test --target ${{ matrix.target }}

--- a/.github/workflows/release-rust-crates.yml
+++ b/.github/workflows/release-rust-crates.yml
@@ -58,12 +58,17 @@ jobs:
         with:
           node-version: '23.0.0'
 
-      - name: List Node directory (Windows)
+      - name: Setup libnode (Windows)
         if: matrix.os == 'windows-latest'
         shell: bash
         run: |
-          echo "Listing Node directory contents:"
-          ls -la "C:\hostedtoolcache\windows\node\23.0.0"
+          echo "Downloading libnode..."
+          curl -L -o libnode.zip https://github.com/metacall/libnode/releases/download/v23.0.0/libnode-amd64-windows.zip
+          echo "Extracting libnode..."
+          unzip libnode.zip
+          echo "Moving libnode.dll to Node installation directory..."
+          cp libnode-amd64-windows/libnode.dll "$RUNNER_TOOL_CACHE/node/$NODE_VERSION/x64/"
+          echo "LIBNODE_PATH=$RUNNER_TOOL_CACHE/node/$NODE_VERSION/x64" >> $GITHUB_ENV
 
       - name: Build
         run: RUST_BACKTRACE=full cargo build --target ${{ matrix.target }} --verbose

--- a/.github/workflows/release-rust-crates.yml
+++ b/.github/workflows/release-rust-crates.yml
@@ -58,14 +58,16 @@ jobs:
         with:
           node-version: '18'
 
-      - name: Find node dlls (Windows)
+      - name: Search for node dlls (Windows)
         if: matrix.os == 'windows-latest'
         shell: bash
         run: |
-          echo "Checking System32:"
-          ls -la /c/Windows/System32/*node*dll 2>/dev/null || echo "Not found in System32"
-          echo -e "\nChecking Windows directory:"
-          ls -la /c/Windows/*node*dll 2>/dev/null || echo "Not found in Windows"
+          echo "Searching for node dlls in Program Files:"
+          find /c/Program\ Files -name "*node*.dll" 2>/dev/null || echo "Not found in Program Files"
+          echo -e "\nSearching in npm cache:"
+          find /c/Users/runneradmin/AppData/Local/npm-cache -name "*node*.dll" 2>/dev/null || echo "Not found in npm cache"
+          echo -e "\nSearching in Node installation:"
+          find /c/hostedtoolcache/windows/node -name "*node*.dll" 2>/dev/null || echo "Not found in Node installation"
 
       - name: Build
         run: RUST_BACKTRACE=full cargo build --target ${{ matrix.target }} --verbose

--- a/.github/workflows/test-golang-bindings.yml
+++ b/.github/workflows/test-golang-bindings.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install libnode
         if: matrix.os == 'windows-latest'
-        run: ./scripts/install_libnode_dll_windows.sh
+        run: .github/scripts/install_libnode_dll_windows.sh
         shell: bash
 
       - name: Run compile script

--- a/.github/workflows/test-golang-bindings.yml
+++ b/.github/workflows/test-golang-bindings.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install libnode
         if: matrix.os == 'windows-latest'
-        run: ./scripts/install_libnode_dll_windows.sh golang
+        run: ./scripts/install_libnode_dll_windows.sh
         shell: bash
 
       - name: Run compile script

--- a/.github/workflows/test-golang-bindings.yml
+++ b/.github/workflows/test-golang-bindings.yml
@@ -30,6 +30,16 @@ jobs:
         with:
           toolchain: 1.80.0
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '23.0.0'
+
+      - name: Install libnode
+        if: matrix.os == 'windows-latest'
+        run: ./scripts/install_libnode_dll_windows.sh golang
+        shell: bash
+
       - name: Run compile script
         run: ./scripts/compile.sh golang
         shell: bash

--- a/.github/workflows/test-nim-bindings.yml
+++ b/.github/workflows/test-nim-bindings.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install libnode
         if: matrix.os == 'windows-latest'
-        run: ./scripts/install_libnode_dll_windows.sh
+        run: .github/scripts/install_libnode_dll_windows.sh
         shell: bash
 
       - name: Run compile script

--- a/.github/workflows/test-nim-bindings.yml
+++ b/.github/workflows/test-nim-bindings.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install libnode
         if: matrix.os == 'windows-latest'
-        run: ./scripts/install_libnode_dll_windows.sh golang
+        run: ./scripts/install_libnode_dll_windows.sh
         shell: bash
 
       - name: Run compile script

--- a/.github/workflows/test-nim-bindings.yml
+++ b/.github/workflows/test-nim-bindings.yml
@@ -30,6 +30,16 @@ jobs:
         with:
           toolchain: 1.80.0
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '23.0.0'
+
+      - name: Install libnode
+        if: matrix.os == 'windows-latest'
+        run: ./scripts/install_libnode_dll_windows.sh golang
+        shell: bash
+
       - name: Run compile script
         run: ./scripts/compile.sh nim
         shell: bash

--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -12,12 +12,12 @@ crate-type = ["cdylib"]
 
 [dependencies]
 # Enable napi6 feature because we want `BigInt` as a proxy for u64
-napi = { version = "2.12.2", default-features = false, features = [
+napi = { version = "2", default-features = false, features = [
     "napi6",
     "async",
 ] }
-napi-derive = "2.12.2"
+napi-derive = "2"
 rust_eth_kzg = { workspace = true, features = ["multithreaded"] }
 
 [build-dependencies]
-napi-build = "2.0.1"
+napi-build = "2"

--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -12,12 +12,12 @@ crate-type = ["cdylib"]
 
 [dependencies]
 # Enable napi6 feature because we want `BigInt` as a proxy for u64
-napi = { version = "2", default-features = false, features = [
+napi = { version = "2.16.3", default-features = false, features = [
     "napi6",
     "async",
 ] }
-napi-derive = "2"
+napi-derive = "2.16.13"
 rust_eth_kzg = { workspace = true, features = ["multithreaded"] }
 
 [build-dependencies]
-napi-build = "2"
+napi-build = "2.1.4"

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -16,7 +16,7 @@
     "version": "napi version"
   },
   "devDependencies": {
-    "@napi-rs/cli": "^2.18.3",
+    "@napi-rs/cli": "^2",
     "@types/jest": "^29.1.2",
     "@types/node": "^20.12.12",
     "@typescript-eslint/eslint-plugin": "^6.14.0",


### PR DESCRIPTION
Windows builds are failing because napi-build is looking for libnode.dll, however this does not come with distributed binaries, hence it is failing to find it on the system.

Here, we just fetch it from a released repo that precompiles them