### PR TITLE
feat(rust-eth-kzg): add `compute_cells`

### DIFF
--- a/cryptography/kzg_multi_open/src/fk20/prover.rs
+++ b/cryptography/kzg_multi_open/src/fk20/prover.rs
@@ -180,6 +180,19 @@ impl FK20Prover {
         self.compute_multi_opening_proofs_poly_coeff(poly_coeff)
     }
 
+    /// Extends the polynomial by computing its coset evaluations
+    pub fn extend_polynomial(&self, input: Input) -> Vec<Vec<Scalar>> {
+        // Convert data to polynomial coefficients
+        let poly_coeff = match input {
+            Input::PolyCoeff(polynomial) => polynomial,
+            Input::Data(mut data) => {
+                reverse_bit_order(&mut data);
+                self.poly_domain.ifft_scalars(data)
+            }
+        };
+        self.compute_coset_evaluations(poly_coeff)
+    }
+
     /// Computes multi-opening proofs over a given polynomial in coefficient form.
     ///
     /// The matching function in the specs is: https://github.com/ethereum/consensus-specs/blob/13ac373a2c284dc66b48ddd2ef0a10537e4e0de6/specs/_features/eip7594/polynomial-commitments-sampling.md#compute_cells_and_kzg_proofs_polynomialcoeff

--- a/eip7594/src/serialization.rs
+++ b/eip7594/src/serialization.rs
@@ -135,7 +135,7 @@ pub(crate) fn serialize_cells_and_proofs(
     proofs: Vec<G1Point>,
 ) -> ([Cell; CELLS_PER_EXT_BLOB], [KZGProof; CELLS_PER_EXT_BLOB]) {
     // Serialize the evaluation sets into `Cell`s.
-    let cells = coset_evaluations_to_cells(coset_evaluations.into_iter());
+    let cells = serialize_cells(coset_evaluations);
 
     // Serialize the proofs into `KZGProof` objects.
     let proofs: Vec<_> = proofs.iter().map(serialize_g1_compressed).collect();
@@ -144,4 +144,9 @@ pub(crate) fn serialize_cells_and_proofs(
         .unwrap_or_else(|_| panic!("expected {} number of proofs", CELLS_PER_EXT_BLOB));
 
     (cells, proofs)
+}
+
+pub(crate) fn serialize_cells(coset_evaluations: Vec<Vec<Scalar>>) -> [Cell; CELLS_PER_EXT_BLOB] {
+    // Serialize the evaluation sets into `Cell`s.
+    coset_evaluations_to_cells(coset_evaluations.into_iter())
 }

--- a/eip7594/tests/compute_cells_and_kzg_proofs.rs
+++ b/eip7594/tests/compute_cells_and_kzg_proofs.rs
@@ -90,8 +90,15 @@ fn test_compute_cells_and_kzg_proofs() {
             }
         };
 
+        // Compute the cells using `compute_cells` and check if it matches
+        // `compute_cells_and_kzg_proofs`
+        let extended_blob = ctx.compute_cells(&blob);
+
         match ctx.compute_cells_and_kzg_proofs(&blob) {
             Ok((cells, proofs)) => {
+                let cells_ = extended_blob.expect("cells should have been computed");
+                assert_eq!(cells_, cells);
+
                 let expected_proofs_and_cells = test.proofs_and_cells.unwrap();
 
                 let expected_proofs = expected_proofs_and_cells.proofs;


### PR DESCRIPTION
Adds back the method to extend blobs -- this was recently added back into the specs