### PR TITLE
feat: Add `tracing` deps and trace time-consuming functions

### DIFF
--- a/cryptography/bls12_381/Cargo.toml
+++ b/cryptography/bls12_381/Cargo.toml
@@ -30,12 +30,15 @@ pairing = { version = "0.23" }
 # as to why we need to pull it in here, even though it is not used directly.
 subtle = { version = ">=2.5.0, <3.0" }
 
+tracing = { version = "0.1.41", default-features = false, features = ["attributes"], optional = true }
+
 [dev-dependencies]
 criterion = "0.5.1"
 rand = "0.8.4"
 
 [features]
 blst-no-threads = ["blst/no-threads"]
+tracing = ["dep:tracing"]
 
 [[bench]]
 name = "benchmark"

--- a/cryptography/kzg_multi_open/Cargo.toml
+++ b/cryptography/kzg_multi_open/Cargo.toml
@@ -18,6 +18,7 @@ bls12_381 = { workspace = true }
 polynomial = { workspace = true }
 maybe_rayon = { workspace = true }
 sha2 = "0.10.8"
+tracing = { version = "0.1.41", default-features = false, features = ["attributes"], optional = true }
 
 [dev-dependencies]
 criterion = "0.5.1"
@@ -26,6 +27,7 @@ rand = "0.8.4"
 [features]
 singlethreaded = ["bls12_381/blst-no-threads"]
 multithreaded = ["maybe_rayon/multithreaded"]
+tracing = ["dep:tracing", "bls12_381/tracing", "polynomial/tracing"]
 
 [[bench]]
 name = "benchmark"

--- a/cryptography/kzg_multi_open/src/fk20/batch_toeplitz.rs
+++ b/cryptography/kzg_multi_open/src/fk20/batch_toeplitz.rs
@@ -102,12 +102,16 @@ impl BatchToeplitzMatrixVecMul {
             .collect();
         let msm_scalars = transpose(col_ffts);
 
-        let result: Vec<_> = self
-            .precomputed_fft_vectors
-            .maybe_par_iter()
-            .zip(msm_scalars)
-            .map(|(points, scalars)| points.msm(scalars))
-            .collect();
+        let result: Vec<_> = {
+            #[cfg(feature = "tracing")]
+            let _span =
+                tracing::info_span!("compute fixed-base msm on matrix-vec-mul result").entered();
+            self.precomputed_fft_vectors
+                .maybe_par_iter()
+                .zip(msm_scalars)
+                .map(|(points, scalars)| points.msm(scalars))
+                .collect()
+        };
 
         // Once the aggregate circulant matrix-vector multiplication is done, we need to take the first half
         // of the result, as the second half are extra terms that were added due to the fact that the Toeplitz matrices

--- a/cryptography/kzg_multi_open/src/fk20/h_poly.rs
+++ b/cryptography/kzg_multi_open/src/fk20/h_poly.rs
@@ -14,6 +14,7 @@ use super::batch_toeplitz::BatchToeplitzMatrixVecMul;
 /// See section 3.1.1 of the FK20 paper for more details.
 ///
 /// FK20 computes the commitments to these polynomials in 3.1.1.
+#[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
 pub(crate) fn compute_h_poly_commitments(
     batch_toeplitz: &BatchToeplitzMatrixVecMul,
     mut polynomial: PolyCoeff,

--- a/cryptography/polynomial/Cargo.toml
+++ b/cryptography/polynomial/Cargo.toml
@@ -15,10 +15,14 @@ workspace = true
 
 [dependencies]
 bls12_381 = { workspace = true }
+tracing = { version = "0.1.41", default-features = false, features = ["attributes"], optional = true }
 
 [dev-dependencies]
 criterion = "0.5.1"
 rand = "0.8.4"
+
+[features]
+tracing = ["dep:tracing", "bls12_381/tracing"]
 
 [[bench]]
 name = "benchmark"

--- a/cryptography/polynomial/src/domain.rs
+++ b/cryptography/polynomial/src/domain.rs
@@ -136,6 +136,7 @@ impl Domain {
     ///
     /// Note: Thinking about an FFT as multiple inner products between powers of the elements
     /// in the domain and the input polynomial makes this easier to visualize.
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     pub fn fft_g1(&self, mut points: Vec<G1Projective>) -> Vec<G1Projective> {
         // Pad the vector of points with zeroes, so that it is the same size as the
         // domain.
@@ -158,6 +159,7 @@ impl Domain {
     ///
     /// This is useful for saving computation on the final scalar multiplication that happens after the
     /// initial FFT is done.
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     pub fn ifft_g1_take_n(
         &self,
         mut points: Vec<G1Projective>,
@@ -187,6 +189,7 @@ impl Domain {
 
     /// Interpolates the points over the domain to get a polynomial
     /// in monomial form.
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     pub fn ifft_scalars(&self, mut points: Vec<Scalar>) -> Vec<Scalar> {
         // Pad the vector with zeroes, so that it is the same size as the
         // domain.

--- a/eip7594/Cargo.toml
+++ b/eip7594/Cargo.toml
@@ -33,6 +33,8 @@ hex = "0.4.3"
 # Serde-yaml has been deprecated, however since we only
 # use it for tests, we will not update it.
 serde_yaml = "0.9.34"
+tracing-subscriber = { version = "0.3.19", features = ["std", "env-filter"] }
+tracing-forest = { version = "0.1.6", features = ["ansi", "smallvec"] }
 
 [[bench]]
 name = "benchmark"

--- a/eip7594/Cargo.toml
+++ b/eip7594/Cargo.toml
@@ -19,10 +19,12 @@ erasure_codes = { workspace = true }
 rayon = { workspace = true, optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tracing = { version = "0.1.41", default-features = false, features = ["attributes"], optional = true }
 
 [features]
 singlethreaded = ["rayon", "kzg_multi_open/singlethreaded"]
 multithreaded = ["rayon", "kzg_multi_open/multithreaded"]
+tracing = ["dep:tracing", "bls12_381/tracing", "kzg_multi_open/tracing"]
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/eip7594/examples/compute_cells_and_kzg_proof.rs
+++ b/eip7594/examples/compute_cells_and_kzg_proof.rs
@@ -1,0 +1,49 @@
+use bls12_381::Scalar;
+use rust_eth_kzg::{constants::BYTES_PER_BLOB, DASContext, ThreadCount, TrustedSetup};
+use std::time::Instant;
+use tracing_forest::util::LevelFilter;
+use tracing_forest::ForestLayer;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Registry};
+
+const POLYNOMIAL_LEN: usize = 4096;
+
+fn dummy_blob() -> [u8; BYTES_PER_BLOB] {
+    let polynomial: Vec<_> = (0..POLYNOMIAL_LEN)
+        .map(|i| -Scalar::from(i as u64))
+        .collect();
+    let blob: Vec<_> = polynomial
+        .into_iter()
+        .flat_map(|scalar| scalar.to_bytes_be())
+        .collect();
+    blob.try_into().unwrap()
+}
+fn main() {
+    let trusted_setup = TrustedSetup::default();
+    let blob = dummy_blob();
+
+    let ctx = DASContext::with_threads(
+        &trusted_setup,
+        ThreadCount::SensibleDefault,
+        bls12_381::fixed_base_msm::UsePrecomp::Yes { width: 8 },
+    );
+
+    println!("Warming up for 3 seconds...");
+
+    let start = Instant::now();
+    while Instant::now().duration_since(start).as_secs() < 3 {
+        ctx.compute_cells_and_kzg_proofs(&blob).unwrap();
+    }
+
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::INFO.into())
+        .from_env_lossy();
+
+    Registry::default()
+        .with(env_filter)
+        .with(ForestLayer::default())
+        .init();
+
+    ctx.compute_cells_and_kzg_proofs(&blob).unwrap();
+}

--- a/eip7594/src/prover.rs
+++ b/eip7594/src/prover.rs
@@ -99,6 +99,9 @@ impl DASContext {
         blob: BlobRef,
     ) -> Result<([Cell; CELLS_PER_EXT_BLOB], [KZGProof; CELLS_PER_EXT_BLOB]), Error> {
         with_optional_threadpool!(self, {
+            #[cfg(feature = "tracing")]
+            let _span = tracing::info_span!("compute_cells_and_kzg_proofs").entered();
+
             // Deserialization
             //
             let scalars = deserialize_blob_to_scalars(blob)?;


### PR DESCRIPTION
- Add dep `tracing` to `bls12_381`, `kzg_multi_open`, `polynomial` and `eip7594`
- Add a example `compute_cells_and_kzg_proof` to show the runtime breakdown

  Running `cargo run --release --features multithreaded,tracing --example compute_cells_and_kzg_proof` we will get something like:

  <img width="728" alt="image" src="https://github.com/user-attachments/assets/d1454867-6965-430e-919c-decb5b86f68b" />
