### PR TITLE
chore: disable blst multithreading

### DIFF
--- a/cryptography/bls12_381/Cargo.toml
+++ b/cryptography/bls12_381/Cargo.toml
@@ -12,7 +12,7 @@ repository = { workspace = true }
 
 [dependencies]
 
-blst = { version = "0.3", default-features = false }
+blst = { version = "0.3", default-features = false, features = ["no-threads"] }
 
 # __private_bench feature is used to allow us to access the base field
 blstrs = { version = "0.7.1", features = ["__private_bench"] }


### PR DESCRIPTION
We can add this back under the multithreaded flag and remove the thread control parameter