### PR TITLE
feat: adopt cache-aware radix-2 fft from Plonky3

### DIFF
--- a/cryptography/erasure_codes/Cargo.toml
+++ b/cryptography/erasure_codes/Cargo.toml
@@ -19,6 +19,9 @@ polynomial = { workspace = true }
 criterion = "0.5.1"
 rand = "0.8.4"
 
+[features]
+multithreaded = ["polynomial/multithreaded"]
+
 [[bench]]
 name = "benchmark"
 harness = false

--- a/cryptography/polynomial/Cargo.toml
+++ b/cryptography/polynomial/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 [dependencies]
 bls12_381 = { workspace = true }
 tracing = { version = "0.1.41", default-features = false, features = ["attributes"], optional = true }
+maybe_rayon = { workspace = true }
 
 [dev-dependencies]
 criterion = "0.5.1"
@@ -23,6 +24,7 @@ rand = "0.8.4"
 
 [features]
 tracing = ["dep:tracing", "bls12_381/tracing"]
+multithreaded = ["maybe_rayon/multithreaded"]
 
 [[bench]]
 name = "benchmark"

--- a/cryptography/polynomial/src/fft.rs
+++ b/cryptography/polynomial/src/fft.rs
@@ -122,15 +122,15 @@ fn dit_layer_bo<T: FFTElement>(
 }
 
 #[inline]
-fn dit<T: FFTElement>(a: &mut T, b: &mut T, twddle: Scalar) {
-    let t = if twddle == Scalar::ONE {
+fn dit<T: FFTElement>(a: &mut T, b: &mut T, twiddle: Scalar) {
+    let t = if twiddle == Scalar::ONE {
         *b
-    } else if twddle == -Scalar::ONE {
+    } else if twiddle == -Scalar::ONE {
         -*b
     } else if *b == FFTElement::zero() {
         FFTElement::zero()
     } else {
-        *b * twddle
+        *b * twiddle
     };
     *b = *a;
     *a = *a + t;

--- a/cryptography/polynomial/src/fft.rs
+++ b/cryptography/polynomial/src/fft.rs
@@ -1,8 +1,11 @@
 use bls12_381::{ff::Field, group::Group, G1Projective, Scalar};
+use maybe_rayon::prelude::*;
+use std::iter::successors;
 use std::ops::{Add, Mul, Neg, Sub};
 
 trait FFTElement:
     Sized
+    + Send
     + Copy
     + PartialEq
     + Eq
@@ -26,49 +29,128 @@ impl FFTElement for G1Projective {
     }
 }
 
-fn fft_inplace<T: FFTElement>(twiddle_factors: &[Scalar], a: &mut [T]) {
-    let n = a.len();
-    let log_n = log2_pow2(n);
-    assert_eq!(n, 1 << log_n);
+// Taken and modified from https://github.com/Plonky3/Plonky3/blob/a374139/dft/src/radix_2_dit_parallel.rs#L106.
+fn fft_inplace<T: FFTElement>(omegas: &[Scalar], twiddle_factors_bo: &[Scalar], values: &mut [T]) {
+    let log_n = log2_pow2(values.len()) as usize;
+    let mid = (log_n + 1) / 2;
 
-    for k in 0..n {
-        let rk = bitreverse(k as u32, log_n) as usize;
-        if k < rk {
-            a.swap(rk, k);
+    // The first half looks like a normal DIT.
+    bitreverse_slice(values);
+    first_half(values, mid, omegas);
+
+    // For the second half, we flip the DIT, working in bit-reversed order,
+    // so the max block size will be at most `1 << (log_n - mid)`.
+    bitreverse_slice(values);
+    second_half(values, mid, twiddle_factors_bo);
+
+    bitreverse_slice(values);
+}
+
+#[allow(clippy::needless_range_loop)]
+fn first_half<T: FFTElement>(values: &mut [T], mid: usize, omegas: &[Scalar]) {
+    values.maybe_par_chunks_mut(1 << mid).for_each(|chunk| {
+        let mut backwards = false;
+        for layer in 0..mid {
+            let half_block_size = 1 << layer;
+            let omega = omegas[layer];
+            dit_layer(chunk, half_block_size, omega, backwards);
+            backwards = !backwards;
         }
-    }
+    });
+}
 
-    let mut m = 1;
-    for s in 0..log_n {
-        let w_m = twiddle_factors[s as usize];
-        for k in (0..n).step_by(2 * m) {
-            let mut w = Scalar::ONE;
-            for j in 0..m {
-                let t = if w == Scalar::ONE {
-                    a[k + j + m]
-                } else if w == -Scalar::ONE {
-                    -a[k + j + m]
-                } else if a[k + j + m] == T::zero() {
-                    T::zero()
-                } else {
-                    a[k + j + m] * w
-                };
-                let u = a[k + j];
-                a[k + j] = u + t;
-                a[k + j + m] = u - t;
-                w *= w_m;
+#[inline]
+fn dit_layer<T: FFTElement>(
+    blocks: &mut [T],
+    half_block_size: usize,
+    omega: Scalar,
+    backwards: bool,
+) {
+    let process_block = |block: &mut [T]| {
+        let (a, b) = block.split_at_mut(half_block_size);
+        let mut twiddle = Scalar::ONE;
+        a.iter_mut().zip(b).for_each(|(a, b)| {
+            dit(a, b, twiddle);
+            twiddle *= omega;
+        });
+    };
+
+    let blocks = blocks.chunks_mut(2 * half_block_size);
+    if backwards {
+        blocks.rev().for_each(process_block);
+    } else {
+        blocks.for_each(process_block);
+    }
+}
+
+fn second_half<T: FFTElement>(values: &mut [T], mid: usize, twiddles_bo: &[Scalar]) {
+    let log_n = log2_pow2(values.len()) as usize;
+    values
+        .maybe_par_chunks_mut(1 << (log_n - mid))
+        .enumerate()
+        .for_each(|(chunk_idx, chunk)| {
+            let mut backwards = false;
+            for layer in mid..log_n {
+                let half_block_size = 1 << (log_n - 1 - layer);
+                let twiddles_bo = &twiddles_bo[chunk_idx << (layer - mid)..];
+                dit_layer_bo(chunk, half_block_size, twiddles_bo, backwards);
+                backwards = !backwards;
             }
-        }
-        m *= 2;
+        });
+}
+
+#[inline]
+fn dit_layer_bo<T: FFTElement>(
+    blocks: &mut [T],
+    half_block_size: usize,
+    twiddles_bo: &[Scalar],
+    backwards: bool,
+) {
+    let process_block = |block: &mut [T], twiddle| {
+        let (a, b) = block.split_at_mut(half_block_size);
+        a.iter_mut().zip(b).for_each(|(a, b)| dit(a, b, twiddle));
+    };
+
+    let blocks_and_twiddles = blocks.chunks_mut(2 * half_block_size).zip(twiddles_bo);
+    if backwards {
+        blocks_and_twiddles
+            .rev()
+            .for_each(|(block, twiddle)| process_block(block, *twiddle));
+    } else {
+        blocks_and_twiddles.for_each(|(block, twiddle)| process_block(block, *twiddle));
     }
 }
 
-pub(crate) fn fft_scalar_inplace(twiddle_factors: &[Scalar], a: &mut [Scalar]) {
-    fft_inplace(twiddle_factors, a);
+#[inline]
+fn dit<T: FFTElement>(a: &mut T, b: &mut T, twddle: Scalar) {
+    let t = if twddle == Scalar::ONE {
+        *b
+    } else if twddle == -Scalar::ONE {
+        -*b
+    } else if *b == FFTElement::zero() {
+        FFTElement::zero()
+    } else {
+        *b * twddle
+    };
+    *b = *a;
+    *a = *a + t;
+    *b = *b - t;
 }
 
-pub(crate) fn fft_g1_inplace(twiddle_factors: &[Scalar], a: &mut [G1Projective]) {
-    fft_inplace(twiddle_factors, a);
+pub(crate) fn fft_scalar_inplace(
+    twiddle_factors: &[Scalar],
+    twiddle_factors_bo: &[Scalar],
+    a: &mut [Scalar],
+) {
+    fft_inplace(twiddle_factors, twiddle_factors_bo, a);
+}
+
+pub(crate) fn fft_g1_inplace(
+    twiddle_factors: &[Scalar],
+    twiddle_factors_bo: &[Scalar],
+    a: &mut [G1Projective],
+) {
+    fft_inplace(twiddle_factors, twiddle_factors_bo, a);
 }
 
 fn bitreverse(mut n: u32, l: u32) -> u32 {
@@ -80,13 +162,36 @@ fn bitreverse(mut n: u32, l: u32) -> u32 {
     r
 }
 
+fn bitreverse_slice<T>(a: &mut [T]) {
+    let n = a.len();
+    let log_n = log2_pow2(n);
+    assert_eq!(n, 1 << log_n);
+
+    for k in 0..n {
+        let rk = bitreverse(k as u32, log_n) as usize;
+        if k < rk {
+            a.swap(rk, k);
+        }
+    }
+}
+
 const fn log2_pow2(n: usize) -> u32 {
     n.trailing_zeros()
 }
 
-pub(crate) fn precompute_twiddle_factors<F: Field>(omega: &F, n: usize) -> Vec<F> {
+/// Returns `[ω_{2}, ω_{4}, ..., ω_{n}]` given input `omega` = `ω_{n}`.
+pub(crate) fn precompute_omegas<F: Field>(omega: &F, n: usize) -> Vec<F> {
     let log_n = log2_pow2(n);
     (0..log_n)
         .map(|s| omega.pow([(n / (1 << (s + 1))) as u64]))
         .collect()
+}
+
+/// Returns `[ω^0, ω^1, ..., ω^{n/2-1}]` in bit-reversed order.
+pub(crate) fn precompute_twiddle_factors_bo<F: Field>(omega: &F, n: usize) -> Vec<F> {
+    let mut twiddle_factors = successors(Some(F::ONE), |twiddle| Some(*twiddle * omega))
+        .take(n / 2)
+        .collect::<Vec<_>>();
+    bitreverse_slice(&mut twiddle_factors);
+    twiddle_factors
 }

--- a/cryptography/polynomial/src/fft.rs
+++ b/cryptography/polynomial/src/fft.rs
@@ -163,6 +163,10 @@ fn bitreverse(mut n: u32, l: u32) -> u32 {
 }
 
 fn bitreverse_slice<T>(a: &mut [T]) {
+    if a.is_empty() {
+        return;
+    }
+
     let n = a.len();
     let log_n = log2_pow2(n);
     assert_eq!(n, 1 << log_n);

--- a/eip7594/examples/compute_cells_and_kzg_proof.rs
+++ b/eip7594/examples/compute_cells_and_kzg_proof.rs
@@ -1,5 +1,5 @@
 use bls12_381::Scalar;
-use rust_eth_kzg::{constants::BYTES_PER_BLOB, DASContext, ThreadCount, TrustedSetup};
+use rust_eth_kzg::{constants::BYTES_PER_BLOB, DASContext, TrustedSetup};
 use std::time::Instant;
 use tracing_forest::util::LevelFilter;
 use tracing_forest::ForestLayer;
@@ -21,9 +21,15 @@ fn main() {
     let trusted_setup = TrustedSetup::default();
     let blob = dummy_blob();
 
+    #[cfg(feature = "multithreaded")]
     let ctx = DASContext::with_threads(
         &trusted_setup,
-        ThreadCount::SensibleDefault,
+        rust_eth_kzg::ThreadCount::SensibleDefault,
+        bls12_381::fixed_base_msm::UsePrecomp::Yes { width: 8 },
+    );
+    #[cfg(feature = "singlethreaded")]
+    let ctx = DASContext::new(
+        &trusted_setup,
         bls12_381::fixed_base_msm::UsePrecomp::Yes { width: 8 },
     );
 

--- a/maybe_rayon/src/multi_threaded.rs
+++ b/maybe_rayon/src/multi_threaded.rs
@@ -2,6 +2,9 @@ pub use rayon::iter::IntoParallelIterator;
 pub use rayon::iter::IntoParallelRefIterator;
 pub use rayon::iter::IntoParallelRefMutIterator;
 pub use rayon::iter::ParallelIterator;
+pub use rayon::join;
+pub use rayon::slice::ChunksMut;
+pub use rayon::slice::ParallelSliceMut;
 
 pub trait MaybeParallelExt: IntoParallelIterator {
     fn maybe_into_par_iter(self) -> <Self as IntoParallelIterator>::Iter
@@ -24,6 +27,13 @@ pub trait MaybeParallelRefMutExt: for<'a> IntoParallelRefMutIterator<'a> {
     }
 }
 
+pub trait MaybeParallelSliceMut<T: Send>: ParallelSliceMut<T> {
+    fn maybe_par_chunks_mut(&mut self, chunk_size: usize) -> ChunksMut<'_, T> {
+        self.par_chunks_mut(chunk_size)
+    }
+}
+
 impl<T: IntoParallelIterator> MaybeParallelExt for T {}
 impl<T: for<'a> IntoParallelRefIterator<'a>> MaybeParallelRefExt for T {}
 impl<T: for<'a> IntoParallelRefMutIterator<'a>> MaybeParallelRefMutExt for T {}
+impl<T: Send, S: ?Sized + ParallelSliceMut<T>> MaybeParallelSliceMut<T> for S {}

--- a/maybe_rayon/src/single_threaded.rs
+++ b/maybe_rayon/src/single_threaded.rs
@@ -1,5 +1,17 @@
 pub use std::iter::IntoIterator;
 pub use std::iter::Iterator;
+pub use std::slice::ChunksMut;
+
+#[inline]
+pub fn join<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
+where
+    A: FnOnce() -> RA + Send,
+    B: FnOnce() -> RB + Send,
+    RA: Send,
+    RB: Send,
+{
+    (oper_a(), oper_b())
+}
 
 pub trait MaybeParallelExt: IntoIterator {
     fn maybe_into_par_iter(self) -> <Self as IntoIterator>::IntoIter
@@ -24,6 +36,10 @@ pub trait MaybeParallelRefMutExt {
     where
         Self: 'a;
     fn maybe_par_iter_mut(&mut self) -> Self::Iter<'_>;
+}
+
+pub trait MaybeParallelSliceMut<T> {
+    fn maybe_par_chunks_mut(&mut self, chunk_size: usize) -> ChunksMut<'_, T>;
 }
 
 impl<T: IntoIterator> MaybeParallelExt for T {}
@@ -55,5 +71,11 @@ where
 
     fn maybe_par_iter_mut(&mut self) -> Self::Iter<'_> {
         self.into_iter()
+    }
+}
+
+impl<T: Send> MaybeParallelSliceMut<T> for [T] {
+    fn maybe_par_chunks_mut(&mut self, chunk_size: usize) -> ChunksMut<'_, T> {
+        self.chunks_mut(chunk_size)
     }
 }


### PR DESCRIPTION
Adopt cache-aware radix-2 fft from Plonky3 https://github.com/Plonky3/Plonky3/blob/a374139/dft/src/radix_2_dit_parallel.rs#L106, but it requires pre-computed twiddles in bit-reversed order, which doubles the memory requirement of `Domain`. If we find this unacceptable for verifier, we could opt-out it for verifier.

### Multithreaded

Before:
```
INFO     compute_cells_and_kzg_proofs [ 45.0ms | 0.50% / 100.00% ]
INFO     ┝━ ifft_scalars [ 905µs | 2.01% ]
INFO     ┕━ compute_multi_opening_proofs_poly_coeff [ 43.9ms | 0.07% / 97.49% ]
INFO        ┝━ compute_h_poly_commitments [ 25.4ms | 0.71% / 56.36% ]
INFO        │  ┝━ compute fixed-base msm on matrix-vec-mul result [ 5.23ms | 11.62% ]
INFO        │  ┕━ ifft_g1_take_n [ 19.8ms | 44.04% ]
INFO        ┝━ compute proof from h_poly_commitments [ 16.6ms | 0.00% / 36.81% ]
INFO        │  ┕━ fft_g1 [ 16.6ms | 36.81% ]
INFO        ┕━ compute_coset_evaluations [ 1.91ms | 4.24% ]
```

After:
```
INFO     compute_cells_and_kzg_proofs [ 17.2ms | 1.18% / 100.00% ]
INFO     ┝━ ifft_scalars [ 225µs | 1.31% ]
INFO     ┕━ compute_multi_opening_proofs_poly_coeff [ 16.8ms | 0.19% / 97.51% ]
INFO        ┝━ compute_h_poly_commitments [ 12.7ms | 1.21% / 73.72% ]
INFO        │  ┝━ compute fixed-base msm on matrix-vec-mul result [ 5.21ms | 30.34% ]
INFO        │  ┕━ ifft_g1_take_n [ 7.25ms | 42.17% ]
INFO        ┝━ compute proof from h_poly_commitments [ 3.71ms | 0.00% / 21.56% ]
INFO        │  ┕━ fft_g1 [ 3.70ms | 21.56% ]
INFO        ┕━ compute_coset_evaluations [ 351µs | 2.04% ]
```

### Singlethreaded

Not slowdown with slightly improvement

Before:
```
INFO     compute_cells_and_kzg_proofs [ 108ms | 0.20% / 100.00% ]
INFO     ┝━ ifft_scalars [ 912µs | 0.84% ]
INFO     ┕━ compute_multi_opening_proofs_poly_coeff [ 107ms | 0.03% / 98.95% ]
INFO        ┝━ compute_h_poly_commitments [ 88.5ms | 0.92% / 81.85% ]
INFO        │  ┝━ compute fixed-base msm on matrix-vec-mul result [ 67.6ms | 62.54% ]
INFO        │  ┕━ ifft_g1_take_n [ 19.9ms | 18.40% ]
INFO        ┝━ compute proof from h_poly_commitments [ 16.5ms | 0.00% / 15.29% ]
INFO        │  ┕━ fft_g1 [ 16.5ms | 15.29% ]
INFO        ┕━ compute_coset_evaluations [ 1.93ms | 1.79% ]
```

After:
```
INFO     compute_cells_and_kzg_proofs [ 108ms | 0.20% / 100.00% ]
INFO     ┝━ ifft_scalars [ 790µs | 0.73% ]
INFO     ┕━ compute_multi_opening_proofs_poly_coeff [ 107ms | 0.03% / 99.07% ]
INFO        ┝━ compute_h_poly_commitments [ 88.4ms | 0.85% / 82.10% ]
INFO        │  ┝━ compute fixed-base msm on matrix-vec-mul result [ 67.6ms | 62.81% ]
INFO        │  ┕━ ifft_g1_take_n [ 19.9ms | 18.44% ]
INFO        ┝━ compute proof from h_poly_commitments [ 16.5ms | 0.00% / 15.36% ]
INFO        │  ┕━ fft_g1 [ 16.5ms | 15.36% ]
INFO        ┕━ compute_coset_evaluations [ 1.69ms | 1.57% ]
```