### PR TITLE
chore: add cargo fmt rules

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -1,0 +1,23 @@
+name: Fmt Check
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  cargo-fmt:
+    name: Cargo fmt
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install nightly toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+          components: rustfmt
+      - name: Rustfmt Check
+        run: cargo fmt --all --check

--- a/bindings/c/build.rs
+++ b/bindings/c/build.rs
@@ -1,5 +1,4 @@
-use std::env;
-use std::path::PathBuf;
+use std::{env, path::PathBuf};
 
 /// The directory where the generated header file will be written.
 const DIR_FOR_HEADER: &str = "build";

--- a/bindings/c/src/blob_to_kzg_commitment.rs
+++ b/bindings/c/src/blob_to_kzg_commitment.rs
@@ -1,7 +1,9 @@
 use rust_eth_kzg::constants::{BYTES_PER_BLOB, BYTES_PER_COMMITMENT};
 
-use crate::pointer_utils::{create_array_ref, deref_const, write_to_slice};
-use crate::{CResult, DASContext};
+use crate::{
+    pointer_utils::{create_array_ref, deref_const, write_to_slice},
+    CResult, DASContext,
+};
 
 pub(crate) fn _blob_to_kzg_commitment(
     ctx: *const DASContext,

--- a/bindings/c/src/compute_cells_and_kzg_proofs.rs
+++ b/bindings/c/src/compute_cells_and_kzg_proofs.rs
@@ -1,6 +1,9 @@
-use crate::pointer_utils::{create_array_ref, deref_const, write_to_2d_slice};
-use crate::{CResult, DASContext};
 use rust_eth_kzg::constants::{BYTES_PER_BLOB, CELLS_PER_EXT_BLOB};
+
+use crate::{
+    pointer_utils::{create_array_ref, deref_const, write_to_2d_slice},
+    CResult, DASContext,
+};
 
 pub(crate) fn _compute_cells_and_kzg_proofs(
     ctx: *const DASContext,

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -13,12 +13,15 @@ use recover_cells_and_kzg_proofs::_recover_cells_and_proofs;
 
 pub(crate) mod pointer_utils;
 
-pub use rust_eth_kzg::constants::{
-    BYTES_PER_BLOB, BYTES_PER_CELL, BYTES_PER_COMMITMENT, BYTES_PER_FIELD_ELEMENT,
-    CELLS_PER_EXT_BLOB, FIELD_ELEMENTS_PER_BLOB,
-};
-pub use rust_eth_kzg::Error;
 use std::ops::Deref;
+
+pub use rust_eth_kzg::{
+    constants::{
+        BYTES_PER_BLOB, BYTES_PER_CELL, BYTES_PER_COMMITMENT, BYTES_PER_FIELD_ELEMENT,
+        CELLS_PER_EXT_BLOB, FIELD_ELEMENTS_PER_BLOB,
+    },
+    Error,
+};
 
 /*
  * Note: All methods in this file have been prefixed with `eth_kzg`.

--- a/bindings/c/src/recover_cells_and_kzg_proofs.rs
+++ b/bindings/c/src/recover_cells_and_kzg_proofs.rs
@@ -1,8 +1,11 @@
-use crate::pointer_utils::{
-    create_slice_view, deref_const, ptr_ptr_to_vec_slice_const, write_to_2d_slice,
-};
-use crate::{CResult, DASContext};
 use rust_eth_kzg::constants::{BYTES_PER_CELL, CELLS_PER_EXT_BLOB};
+
+use crate::{
+    pointer_utils::{
+        create_slice_view, deref_const, ptr_ptr_to_vec_slice_const, write_to_2d_slice,
+    },
+    CResult, DASContext,
+};
 
 pub(crate) fn _recover_cells_and_proofs(
     ctx: *const DASContext,

--- a/bindings/c/src/verify_cells_and_kzg_proofs_batch.rs
+++ b/bindings/c/src/verify_cells_and_kzg_proofs_batch.rs
@@ -1,6 +1,9 @@
-use crate::pointer_utils::{create_slice_view, deref_const, deref_mut, ptr_ptr_to_vec_slice_const};
-use crate::{verification_result_to_bool_cresult, CResult, DASContext};
 use rust_eth_kzg::constants::{BYTES_PER_CELL, BYTES_PER_COMMITMENT};
+
+use crate::{
+    pointer_utils::{create_slice_view, deref_const, deref_mut, ptr_ptr_to_vec_slice_const},
+    verification_result_to_bool_cresult, CResult, DASContext,
+};
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn _verify_cell_kzg_proof_batch(

--- a/bindings/java/rust_code/src/lib.rs
+++ b/bindings/java/rust_code/src/lib.rs
@@ -1,7 +1,9 @@
 use c_eth_kzg::DASContext;
-use jni::objects::{JByteArray, JClass, JLongArray, JObject, JObjectArray, JValue};
-use jni::sys::{jboolean, jlong};
-use jni::JNIEnv;
+use jni::{
+    objects::{JByteArray, JClass, JLongArray, JObject, JObjectArray, JValue},
+    sys::{jboolean, jlong},
+    JNIEnv,
+};
 
 mod errors;
 use errors::Error;

--- a/bindings/nim/rust_code/build.rs
+++ b/bindings/nim/rust_code/build.rs
@@ -1,5 +1,4 @@
-use std::env;
-use std::path::PathBuf;
+use std::{env, path::PathBuf};
 
 /// The path where the generated header file will be written relative to bindings folder.
 const PATH_FOR_NIM_HEADER: &str = "nim/nim_code/nim_eth_kzg/header.nim";

--- a/crates/cryptography/bls12_381/src/batch_addition.rs
+++ b/crates/cryptography/bls12_381/src/batch_addition.rs
@@ -1,7 +1,8 @@
-use crate::batch_inversion::{batch_inverse, batch_inverse_scratch_pad};
 use blstrs::{Fp, G1Affine, G1Projective};
 use ff::Field;
 use group::{prime::PrimeCurveAffine, Group};
+
+use crate::batch_inversion::{batch_inverse, batch_inverse_scratch_pad};
 
 /// Adds two elliptic curve points (affine coordinates) using the point addition/doubling formula.
 ///
@@ -233,10 +234,10 @@ pub(crate) fn multi_batch_addition_binary_tree_stride(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use proptest::prelude::*;
-    use rand::rngs::StdRng;
-    use rand::SeedableRng;
+    use rand::{rngs::StdRng, SeedableRng};
+
+    use super::*;
 
     #[test]
     fn test_batch_addition() {

--- a/crates/cryptography/bls12_381/src/batch_inversion.rs
+++ b/crates/cryptography/bls12_381/src/batch_inversion.rs
@@ -58,10 +58,11 @@ pub fn batch_inverse_scratch_pad<F: Field>(v: &mut [F], scratchpad: &mut Vec<F>)
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use blstrs::Scalar;
     use proptest::prelude::*;
     use rand::{rngs::StdRng, SeedableRng};
+
+    use super::*;
 
     fn random_elements(num_elements: usize) -> Vec<Scalar> {
         (0..num_elements)

--- a/crates/cryptography/bls12_381/src/booth_encoding.rs
+++ b/crates/cryptography/bls12_381/src/booth_encoding.rs
@@ -49,10 +49,11 @@ pub fn get_booth_index(window_index: usize, window_size: usize, el: &[u8]) -> i3
 mod tests {
     use std::ops::Neg;
 
-    use super::get_booth_index;
-    use crate::G1Point;
     use blstrs::{G1Projective, Scalar};
     use ff::{Field, PrimeField};
+
+    use super::get_booth_index;
+    use crate::G1Point;
 
     #[test]
     fn smoke_scalar_mul() {

--- a/crates/cryptography/bls12_381/src/fixed_base_msm.rs
+++ b/crates/cryptography/bls12_381/src/fixed_base_msm.rs
@@ -1,8 +1,10 @@
-use crate::lincomb::g1_lincomb;
-use crate::{fixed_base_msm_window::FixedBaseMSMPrecompWindow, G1Projective, Scalar};
 use blst::blst_p1_affine;
 use blstrs::{Fp, G1Affine};
 use ff::PrimeField;
+
+use crate::{
+    fixed_base_msm_window::FixedBaseMSMPrecompWindow, lincomb::g1_lincomb, G1Projective, Scalar,
+};
 
 /// A precomputed structure for performing fixed-base multi-scalar multiplication (MSM) in G1 using BLST.
 ///
@@ -192,11 +194,11 @@ impl FixedBaseMSMPrecompBLST {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use ff::Field;
     use group::Group;
-    use rand::thread_rng;
-    use rand::{rngs::StdRng, SeedableRng};
+    use rand::{rngs::StdRng, thread_rng, SeedableRng};
+
+    use super::*;
 
     fn random_g1_affines(n: usize) -> Vec<G1Affine> {
         let mut rng = StdRng::seed_from_u64(42);

--- a/crates/cryptography/bls12_381/src/fixed_base_msm_window.rs
+++ b/crates/cryptography/bls12_381/src/fixed_base_msm_window.rs
@@ -1,10 +1,11 @@
+use blstrs::G1Affine;
+use ff::PrimeField;
+use group::Group;
+
 use crate::{
     batch_addition::multi_batch_addition_binary_tree_stride, booth_encoding::get_booth_index,
     g1_batch_normalize, G1Projective, Scalar,
 };
-use blstrs::G1Affine;
-use ff::PrimeField;
-use group::Group;
 
 /// A precomputed window-based structure for fast fixed-base multi-scalar multiplication (MSM) in G1.
 ///
@@ -171,9 +172,10 @@ impl FixedBaseMSMPrecompWindow {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use ff::Field;
     use group::prime::PrimeCurveAffine;
+
+    use super::*;
 
     #[test]
     fn precomp_lookup_table() {

--- a/crates/cryptography/bls12_381/src/lib.rs
+++ b/crates/cryptography/bls12_381/src/lib.rs
@@ -1,5 +1,4 @@
-use group::Group;
-use group::{prime::PrimeCurveAffine, Curve};
+use group::{prime::PrimeCurveAffine, Curve, Group};
 use pairing::{MillerLoopResult, MultiMillerLoop};
 
 pub mod batch_addition;
@@ -137,9 +136,10 @@ pub fn reduce_bytes_to_scalar_bias(bytes: [u8; 32]) -> Scalar {
 
 #[cfg(test)]
 mod tests {
+    use rand::rngs::OsRng;
+
     use super::*;
     use crate::ff::Field;
-    use rand::rngs::OsRng;
 
     /// BLS12-381 scalar field modulus (r)
     const BLS12_381_R: [u8; 32] = [

--- a/crates/cryptography/bls12_381/src/lincomb.rs
+++ b/crates/cryptography/bls12_381/src/lincomb.rs
@@ -1,5 +1,6 @@
-use crate::{G1Point, G1Projective, G2Point, G2Projective, Scalar};
 use group::{prime::PrimeCurveAffine, Group};
+
+use crate::{G1Point, G1Projective, G2Point, G2Projective, Scalar};
 
 /// A multi-scalar multiplication algorithm over G1 elements
 ///
@@ -102,9 +103,10 @@ pub fn g2_lincomb(points: &[G2Point], scalars: &[Scalar]) -> Option<G2Projective
 
 #[cfg(test)]
 mod tests {
+    use rand::{rngs::StdRng, SeedableRng};
+
     use super::*;
     use crate::ff::Field;
-    use rand::{rngs::StdRng, SeedableRng};
 
     #[test]
     fn blst_footgun() {

--- a/crates/cryptography/erasure_codes/benches/benchmark.rs
+++ b/crates/cryptography/erasure_codes/benches/benchmark.rs
@@ -1,7 +1,8 @@
+use std::ops::Range;
+
 use bls12_381::Scalar;
 use crate_crypto_internal_eth_kzg_erasure_codes::{BlockErasureIndices, ReedSolomon};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use std::ops::Range;
 
 pub fn bench_erasure_code_decoding_4096_8192(c: &mut Criterion) {
     const POLYNOMIAL_LEN: usize = 4096;

--- a/crates/cryptography/erasure_codes/src/reed_solomon.rs
+++ b/crates/cryptography/erasure_codes/src/reed_solomon.rs
@@ -1,11 +1,13 @@
-use crate::errors::RSError;
+use std::ops::Deref;
+
 use bls12_381::{
     batch_inversion::batch_inverse,
     ff::{Field, PrimeField},
     Scalar,
 };
 use polynomial::{domain::Domain, poly_coeff::vanishing_poly, CosetFFT};
-use std::ops::Deref;
+
+use crate::errors::RSError;
 
 /// `ErasurePattern` is an abstraction created to capture the idea
 /// that erasures do not appear in completely random locations.

--- a/crates/cryptography/kzg_multi_open/benches/benchmark.rs
+++ b/crates/cryptography/kzg_multi_open/benches/benchmark.rs
@@ -1,10 +1,9 @@
-use bls12_381::fixed_base_msm::UsePrecomp;
-use bls12_381::group::Group;
-use bls12_381::{ff::Field, G1Projective};
-use bls12_381::{g1_batch_normalize, g2_batch_normalize, G2Projective, Scalar};
-use crate_crypto_kzg_multi_open_fk20::Verifier;
+use bls12_381::{
+    ff::Field, fixed_base_msm::UsePrecomp, g1_batch_normalize, g2_batch_normalize, group::Group,
+    G1Projective, G2Projective, Scalar,
+};
 use crate_crypto_kzg_multi_open_fk20::{
-    commit_key::CommitKey, verification_key::VerificationKey, Prover, ProverInput,
+    commit_key::CommitKey, verification_key::VerificationKey, Prover, ProverInput, Verifier,
 };
 use criterion::{criterion_group, criterion_main, Criterion};
 

--- a/crates/cryptography/kzg_multi_open/src/fk20/batch_toeplitz.rs
+++ b/crates/cryptography/kzg_multi_open/src/fk20/batch_toeplitz.rs
@@ -1,10 +1,11 @@
-use crate::fk20::toeplitz::{CirculantMatrix, ToeplitzMatrix};
 use bls12_381::{
     fixed_base_msm::{FixedBaseMSM, UsePrecomp},
     g1_batch_normalize, G1Point, G1Projective,
 };
 use maybe_rayon::prelude::*;
 use polynomial::domain::Domain;
+
+use crate::fk20::toeplitz::{CirculantMatrix, ToeplitzMatrix};
 
 /// BatchToeplitzMatrixVecMul allows one to compute multiple matrix vector multiplications
 /// and sum them together.
@@ -163,11 +164,11 @@ pub(crate) fn transpose<T: Clone>(v: Vec<Vec<T>>) -> Vec<Vec<T>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::fk20::batch_toeplitz::BatchToeplitzMatrixVecMul;
-    use crate::fk20::toeplitz::ToeplitzMatrix;
-    use bls12_381::fixed_base_msm::UsePrecomp;
-    use bls12_381::group::Group;
-    use bls12_381::{g1_batch_normalize, G1Projective, Scalar};
+    use bls12_381::{
+        fixed_base_msm::UsePrecomp, g1_batch_normalize, group::Group, G1Projective, Scalar,
+    };
+
+    use crate::fk20::{batch_toeplitz::BatchToeplitzMatrixVecMul, toeplitz::ToeplitzMatrix};
 
     #[test]
     fn smoke_aggregated_matrix_vector_mul() {

--- a/crates/cryptography/kzg_multi_open/src/fk20/cosets.rs
+++ b/crates/cryptography/kzg_multi_open/src/fk20/cosets.rs
@@ -233,11 +233,11 @@ pub(crate) fn generate_cosets(
 
 #[cfg(test)]
 mod tests {
-    use rand::{seq::SliceRandom, thread_rng};
     use std::collections::HashSet;
 
     use bls12_381::Scalar;
     use polynomial::{domain::Domain, poly_coeff::poly_eval};
+    use rand::{seq::SliceRandom, thread_rng};
 
     use crate::fk20::{
         batch_toeplitz::transpose,

--- a/crates/cryptography/kzg_multi_open/src/fk20/h_poly.rs
+++ b/crates/cryptography/kzg_multi_open/src/fk20/h_poly.rs
@@ -1,8 +1,8 @@
-use crate::fk20::toeplitz::ToeplitzMatrix;
 use bls12_381::{ff::Field, G1Projective, Scalar};
 use polynomial::poly_coeff::PolyCoeff;
 
 use super::batch_toeplitz::BatchToeplitzMatrixVecMul;
+use crate::fk20::toeplitz::ToeplitzMatrix;
 
 /// Computes the `h` polynomials for the FK20 proofs.
 ///
@@ -69,6 +69,8 @@ pub(crate) fn take_every_nth<T: Clone + Copy>(list: &[T], n: usize) -> Vec<Vec<T
 
 #[cfg(test)]
 mod tests {
+    use bls12_381::{fixed_base_msm::UsePrecomp, Scalar};
+
     use crate::{
         create_insecure_commit_verification_keys,
         fk20::{
@@ -77,7 +79,6 @@ mod tests {
             prover::FK20Prover,
         },
     };
-    use bls12_381::{fixed_base_msm::UsePrecomp, Scalar};
 
     #[test]
     fn smoke_test_downsample() {

--- a/crates/cryptography/kzg_multi_open/src/fk20/naive.rs
+++ b/crates/cryptography/kzg_multi_open/src/fk20/naive.rs
@@ -1,9 +1,8 @@
-use crate::commit_key::CommitKey;
 use bls12_381::{g1_batch_normalize, G1Point, Scalar};
-use polynomial::domain::Domain;
-use polynomial::poly_coeff::PolyCoeff;
+use polynomial::{domain::Domain, poly_coeff::PolyCoeff};
 
 use super::cosets::reverse_bit_order;
+use crate::commit_key::CommitKey;
 
 /// This is doing \floor{f(x) / x^d}
 /// which essentially means removing the first d coefficients
@@ -108,8 +107,9 @@ fn compute_coset_evaluations(
 
 #[cfg(test)]
 mod tests {
-    use crate::fk20::naive::shift_polynomial;
     use bls12_381::Scalar;
+
+    use crate::fk20::naive::shift_polynomial;
 
     #[test]
     fn check_divide_by_monomial_floor() {

--- a/crates/cryptography/kzg_multi_open/src/fk20/prover.rs
+++ b/crates/cryptography/kzg_multi_open/src/fk20/prover.rs
@@ -1,13 +1,16 @@
-use crate::commit_key::CommitKey;
-use crate::fk20::batch_toeplitz::BatchToeplitzMatrixVecMul;
-use crate::fk20::cosets::reverse_bit_order;
-use crate::fk20::h_poly::take_every_nth;
-use bls12_381::fixed_base_msm::UsePrecomp;
-use bls12_381::group::prime::PrimeCurveAffine;
-use bls12_381::{g1_batch_normalize, G1Point, Scalar};
+use bls12_381::{
+    fixed_base_msm::UsePrecomp, g1_batch_normalize, group::prime::PrimeCurveAffine, G1Point, Scalar,
+};
 use polynomial::{domain::Domain, poly_coeff::PolyCoeff};
 
 use super::h_poly::compute_h_poly_commitments;
+use crate::{
+    commit_key::CommitKey,
+    fk20::{
+        batch_toeplitz::BatchToeplitzMatrixVecMul, cosets::reverse_bit_order,
+        h_poly::take_every_nth,
+    },
+};
 
 /// Input contains the various structures that we can make FK20 proofs over.
 pub enum Input {
@@ -235,13 +238,14 @@ impl FK20Prover {
 mod tests {
     use std::collections::HashSet;
 
+    use bls12_381::{fixed_base_msm::UsePrecomp, Scalar};
+
     use super::{FK20Prover, Input};
     use crate::{
         create_insecure_commit_verification_keys,
         fk20::{cosets::generate_cosets, naive as fk20naive, verifier::FK20Verifier},
         naive as kzgnaive,
     };
-    use bls12_381::{fixed_base_msm::UsePrecomp, Scalar};
 
     #[test]
     fn data_is_contained_in_the_first_section_of_cells() {

--- a/crates/cryptography/kzg_multi_open/src/fk20/toeplitz.rs
+++ b/crates/cryptography/kzg_multi_open/src/fk20/toeplitz.rs
@@ -262,9 +262,10 @@ impl DenseMatrix {
 
 #[cfg(test)]
 mod tests {
+    use bls12_381::Scalar;
+
     use super::DenseMatrix;
     use crate::fk20::toeplitz::ToeplitzMatrix;
-    use bls12_381::Scalar;
 
     fn is_toeplitz(dense_matrix: &DenseMatrix) -> bool {
         let num_rows = dense_matrix.inner.len();

--- a/crates/cryptography/kzg_multi_open/src/fk20/verifier.rs
+++ b/crates/cryptography/kzg_multi_open/src/fk20/verifier.rs
@@ -1,16 +1,17 @@
-use crate::{
-    fk20::cosets::{coset_gens, reverse_bit_order},
-    verification_key::VerificationKey,
-};
+use std::mem::size_of;
+
 use bls12_381::{
     ff::Field, g1_batch_normalize, lincomb::g1_lincomb, multi_pairings,
     reduce_bytes_to_scalar_bias, G1Point, G2Point, G2Prepared, Scalar,
 };
 use polynomial::{domain::Domain, poly_coeff::poly_add, CosetFFT};
 use sha2::{Digest, Sha256};
-use std::mem::size_of;
 
 use super::errors::VerifierError;
+use crate::{
+    fk20::cosets::{coset_gens, reverse_bit_order},
+    verification_key::VerificationKey,
+};
 
 /// CosetIndex is a reference to a coset.
 ///
@@ -364,8 +365,9 @@ fn compute_sum_interpolation_poly(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use bls12_381::Scalar;
+
+    use super::*;
 
     #[test]
     fn test_compute_powers() {

--- a/crates/cryptography/kzg_multi_open/src/lib.rs
+++ b/crates/cryptography/kzg_multi_open/src/lib.rs
@@ -13,9 +13,10 @@ mod naive;
 #[cfg(test)]
 pub(crate) fn create_insecure_commit_verification_keys(
 ) -> (commit_key::CommitKey, verification_key::VerificationKey) {
-    use bls12_381::ff::Field;
-    use bls12_381::group::Group;
-    use bls12_381::{g1_batch_normalize, g2_batch_normalize, G1Projective, G2Projective, Scalar};
+    use bls12_381::{
+        ff::Field, g1_batch_normalize, g2_batch_normalize, group::Group, G1Projective,
+        G2Projective, Scalar,
+    };
     use commit_key::CommitKey;
     use verification_key::VerificationKey;
 

--- a/crates/cryptography/kzg_multi_open/src/naive.rs
+++ b/crates/cryptography/kzg_multi_open/src/naive.rs
@@ -1,8 +1,9 @@
-use crate::{commit_key::CommitKey, verification_key::VerificationKey};
 use bls12_381::{ff::Field, multi_pairings, G1Point, G1Projective, G2Point, G2Prepared, Scalar};
 use polynomial::poly_coeff::{
     lagrange_interpolate, poly_eval, poly_sub, vanishing_poly, PolyCoeff,
 };
+
+use crate::{commit_key::CommitKey, verification_key::VerificationKey};
 
 /// This modules contains code to create and verify opening proofs in a naive way.
 /// It is also general, meaning the points we are creating opening proofs

--- a/crates/cryptography/polynomial/benches/benchmark.rs
+++ b/crates/cryptography/polynomial/benches/benchmark.rs
@@ -1,5 +1,4 @@
-use bls12_381::Scalar;
-use bls12_381::{ff::Field, group::Group, G1Projective};
+use bls12_381::{ff::Field, group::Group, G1Projective, Scalar};
 use crate_crypto_internal_eth_kzg_polynomial::{domain::Domain, poly_coeff::poly_eval};
 use criterion::{criterion_group, criterion_main, Criterion};
 

--- a/crates/cryptography/polynomial/src/domain.rs
+++ b/crates/cryptography/polynomial/src/domain.rs
@@ -1,12 +1,13 @@
-use crate::coset_fft::CosetFFT;
-use crate::fft::{
-    fft_g1_inplace, fft_scalar_inplace, precompute_omegas, precompute_twiddle_factors_bo,
-};
-use crate::poly_coeff::PolyCoeff;
-use bls12_381::ff::{Field, PrimeField};
 use bls12_381::{
+    ff::{Field, PrimeField},
     group::Group,
-    {G1Projective, Scalar},
+    G1Projective, Scalar,
+};
+
+use crate::{
+    coset_fft::CosetFFT,
+    fft::{fft_g1_inplace, fft_scalar_inplace, precompute_omegas, precompute_twiddle_factors_bo},
+    poly_coeff::PolyCoeff,
 };
 
 /// A struct representing a set of points that are roots of unity,
@@ -231,9 +232,8 @@ impl Domain {
 
 #[cfg(test)]
 mod tests {
-    use crate::poly_coeff::poly_eval;
-
     use super::*;
+    use crate::poly_coeff::poly_eval;
 
     #[test]
     fn largest_root_of_unity_has_correct_order() {

--- a/crates/cryptography/polynomial/src/fft.rs
+++ b/crates/cryptography/polynomial/src/fft.rs
@@ -1,7 +1,10 @@
+use std::{
+    iter::successors,
+    ops::{Add, Mul, Neg, Sub},
+};
+
 use bls12_381::{ff::Field, group::Group, G1Projective, Scalar};
 use maybe_rayon::prelude::*;
-use std::iter::successors;
-use std::ops::{Add, Mul, Neg, Sub};
 
 trait FFTElement:
     Sized

--- a/crates/cryptography/polynomial/src/poly_coeff.rs
+++ b/crates/cryptography/polynomial/src/poly_coeff.rs
@@ -1,5 +1,4 @@
-use bls12_381::ff::Field;
-use bls12_381::Scalar;
+use bls12_381::{ff::Field, Scalar};
 
 // This file contains methods on a polynomial in coefficient form.
 
@@ -157,8 +156,9 @@ pub fn lagrange_interpolate(points: &[(Scalar, Scalar)]) -> Option<Vec<Scalar>> 
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use bls12_381::ff::Field;
+
+    use super::*;
 
     fn naive_poly_eval(poly: &PolyCoeff, value: &Scalar) -> Scalar {
         let mut result = Scalar::ZERO;

--- a/crates/eip7594/examples/compute_cells_and_kzg_proof.rs
+++ b/crates/eip7594/examples/compute_cells_and_kzg_proof.rs
@@ -1,11 +1,9 @@
+use std::time::Instant;
+
 use bls12_381::Scalar;
 use rust_eth_kzg::{constants::BYTES_PER_BLOB, DASContext, TrustedSetup};
-use std::time::Instant;
-use tracing_forest::util::LevelFilter;
-use tracing_forest::ForestLayer;
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::{EnvFilter, Registry};
+use tracing_forest::{util::LevelFilter, ForestLayer};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Registry};
 
 const POLYNOMIAL_LEN: usize = 4096;
 

--- a/crates/eip7594/src/errors.rs
+++ b/crates/eip7594/src/errors.rs
@@ -1,5 +1,6 @@
-use crate::CellIndex;
 use erasure_codes::errors::RSError;
+
+use crate::CellIndex;
 
 /// Errors that can occur either during proving, verification or serialization.
 #[derive(Debug)]

--- a/crates/eip7594/src/prover.rs
+++ b/crates/eip7594/src/prover.rs
@@ -1,9 +1,6 @@
 use bls12_381::fixed_base_msm::UsePrecomp;
 use erasure_codes::ReedSolomon;
-use kzg_multi_open::{
-    commit_key::CommitKey,
-    {Prover, ProverInput},
-};
+use kzg_multi_open::{commit_key::CommitKey, Prover, ProverInput};
 
 use crate::{
     constants::{

--- a/crates/eip7594/src/serialization.rs
+++ b/crates/eip7594/src/serialization.rs
@@ -1,3 +1,6 @@
+use bls12_381::{G1Point, Scalar};
+
+pub use crate::errors::SerializationError;
 use crate::{
     constants::{
         BYTES_PER_BLOB, BYTES_PER_CELL, BYTES_PER_FIELD_ELEMENT, BYTES_PER_G1_POINT,
@@ -5,9 +8,6 @@ use crate::{
     },
     Cell, KZGProof,
 };
-use bls12_381::{G1Point, Scalar};
-
-pub use crate::errors::SerializationError;
 
 fn deserialize_bytes_to_scalars(bytes: &[u8]) -> Result<Vec<Scalar>, SerializationError> {
     // Check that the bytes are a multiple of the scalar size

--- a/crates/eip7594/src/verifier.rs
+++ b/crates/eip7594/src/verifier.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
-pub use crate::errors::VerifierError;
+use kzg_multi_open::{verification_key::VerificationKey, Verifier};
 
+pub use crate::errors::VerifierError;
 use crate::{
     constants::{CELLS_PER_EXT_BLOB, FIELD_ELEMENTS_PER_EXT_BLOB},
     errors::Error,
@@ -9,7 +10,6 @@ use crate::{
     trusted_setup::TrustedSetup,
     Bytes48Ref, CellIndex, CellRef, DASContext,
 };
-use kzg_multi_open::{verification_key::VerificationKey, Verifier};
 
 /// The context object that is used to call functions in the verifier API.
 #[derive(Debug)]

--- a/crates/eip7594/tests/blob_to_kzg_commitment.rs
+++ b/crates/eip7594/tests/blob_to_kzg_commitment.rs
@@ -1,16 +1,17 @@
+use std::fs;
+
 use common::collect_test_files;
 use rust_eth_kzg::constants::BYTES_PER_BLOB;
 use serde_::TestVector;
-use std::fs;
 
 mod common;
 
 mod serde_ {
 
-    use crate::common::UnsafeBytes;
+    use serde::Deserialize;
 
     use super::common::bytes_from_hex;
-    use serde::Deserialize;
+    use crate::common::UnsafeBytes;
 
     #[derive(Deserialize)]
     struct YamlInput {

--- a/crates/eip7594/tests/common.rs
+++ b/crates/eip7594/tests/common.rs
@@ -4,9 +4,10 @@
 /// could give us 47.
 pub type UnsafeBytes = Vec<u8>;
 
-use std::fs;
-use std::io;
-use std::path::{Path, PathBuf};
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
 
 pub fn collect_test_files<P: AsRef<Path>>(dir: P) -> io::Result<Vec<PathBuf>> {
     let mut files = Vec::new();

--- a/crates/eip7594/tests/compute_cells_and_kzg_proofs.rs
+++ b/crates/eip7594/tests/compute_cells_and_kzg_proofs.rs
@@ -1,14 +1,15 @@
+use std::fs;
+
 use common::collect_test_files;
 use serde_::TestVector;
-use std::fs;
 
 mod common;
 
 mod serde_ {
-    use crate::common::UnsafeBytes;
+    use serde::Deserialize;
 
     use super::common::bytes_from_hex;
-    use serde::Deserialize;
+    use crate::common::UnsafeBytes;
 
     #[derive(Deserialize)]
     struct YamlInput {

--- a/crates/eip7594/tests/recover_cells_and_kzg_proofs.rs
+++ b/crates/eip7594/tests/recover_cells_and_kzg_proofs.rs
@@ -1,13 +1,14 @@
+use std::fs;
+
 use common::collect_test_files;
 use serde_::TestVector;
-use std::fs;
 
 mod common;
 
 mod serde_ {
-    use crate::common::{bytes_from_hex, UnsafeBytes};
-
     use serde::Deserialize;
+
+    use crate::common::{bytes_from_hex, UnsafeBytes};
 
     #[derive(Deserialize)]
     struct YamlInput {

--- a/crates/eip7594/tests/verify_cell_kzg_proof_batch.rs
+++ b/crates/eip7594/tests/verify_cell_kzg_proof_batch.rs
@@ -1,13 +1,14 @@
+use std::fs;
+
 use common::collect_test_files;
 use serde_::TestVector;
-use std::fs;
 
 mod common;
 
 mod serde_ {
-    use crate::common::{bytes_from_hex, UnsafeBytes};
-
     use serde::Deserialize;
+
+    use crate::common::{bytes_from_hex, UnsafeBytes};
 
     #[derive(Deserialize)]
     struct YamlInput {

--- a/crates/maybe_rayon/src/lib.rs
+++ b/crates/maybe_rayon/src/lib.rs
@@ -9,9 +9,8 @@ pub use multi_threaded::*;
 pub use single_threaded::*;
 
 pub mod prelude {
-    pub use crate::MaybeParallelRefExt;
-    pub use crate::MaybeParallelRefMutExt;
-    pub use crate::*;
     #[cfg(feature = "multithreaded")]
     pub use rayon::prelude::*;
+
+    pub use crate::{MaybeParallelRefExt, MaybeParallelRefMutExt, *};
 }

--- a/crates/maybe_rayon/src/multi_threaded.rs
+++ b/crates/maybe_rayon/src/multi_threaded.rs
@@ -1,10 +1,10 @@
-pub use rayon::iter::IntoParallelIterator;
-pub use rayon::iter::IntoParallelRefIterator;
-pub use rayon::iter::IntoParallelRefMutIterator;
-pub use rayon::iter::ParallelIterator;
-pub use rayon::join;
-pub use rayon::slice::ChunksMut;
-pub use rayon::slice::ParallelSliceMut;
+pub use rayon::{
+    iter::{
+        IntoParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator,
+    },
+    join,
+    slice::{ChunksMut, ParallelSliceMut},
+};
 
 pub trait MaybeParallelExt: IntoParallelIterator {
     fn maybe_into_par_iter(self) -> <Self as IntoParallelIterator>::Iter

--- a/crates/maybe_rayon/src/single_threaded.rs
+++ b/crates/maybe_rayon/src/single_threaded.rs
@@ -1,6 +1,7 @@
-pub use std::iter::IntoIterator;
-pub use std::iter::Iterator;
-pub use std::slice::ChunksMut;
+pub use std::{
+    iter::{IntoIterator, Iterator},
+    slice::ChunksMut,
+};
 
 #[inline]
 pub fn join<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+reorder_imports = true
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"


### PR DESCRIPTION
@kevaundray It classifies the imports automatically so that:
- They are easier to manage
- This minimizes git diff when reviewing/merging/doing PRs