### PR TITLE
chore: rm useless functions in eip7594

### DIFF
--- a/crates/eip7594/src/lib.rs
+++ b/crates/eip7594/src/lib.rs
@@ -89,12 +89,4 @@ impl DASContext {
             verifier_ctx: VerifierContext::new(trusted_setup),
         }
     }
-
-    pub const fn prover_ctx(&self) -> &ProverContext {
-        &self.prover_ctx
-    }
-
-    pub const fn verifier_ctx(&self) -> &VerifierContext {
-        &self.verifier_ctx
-    }
 }


### PR DESCRIPTION
@kevaundray As the fields corresponding to these getters are public, I think they become redundant.