### PR TITLE
feat: add crate `eip4844` and the corresponding APIs and tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "bindings/nim/rust_code",
     "bindings/csharp/rust_code",
 
+    "crates/eip4844",
     "crates/eip7594",
     "crates/maybe_rayon",
 

--- a/crates/cryptography/bls12_381/Cargo.toml
+++ b/crates/cryptography/bls12_381/Cargo.toml
@@ -30,10 +30,6 @@ pairing = { version = "0.23" }
 # as to why we need to pull it in here, even though it is not used directly.
 subtle = { version = ">=2.5.0, <3.0" }
 
-tracing = { version = "0.1.41", default-features = false, features = [
-    "attributes",
-], optional = true }
-
 [dev-dependencies]
 criterion = "0.5.1"
 rand = "0.8.4"
@@ -41,7 +37,6 @@ proptest = "1.6"
 
 [features]
 blst-no-threads = ["blst/no-threads"]
-tracing = ["dep:tracing"]
 
 [[bench]]
 name = "benchmark"

--- a/crates/cryptography/kzg_multi_open/Cargo.toml
+++ b/crates/cryptography/kzg_multi_open/Cargo.toml
@@ -27,7 +27,7 @@ rand = "0.8.4"
 [features]
 singlethreaded = ["bls12_381/blst-no-threads"]
 multithreaded = ["maybe_rayon/multithreaded"]
-tracing = ["dep:tracing", "bls12_381/tracing", "polynomial/tracing"]
+tracing = ["dep:tracing", "polynomial/tracing"]
 
 [[bench]]
 name = "benchmark"

--- a/crates/cryptography/polynomial/Cargo.toml
+++ b/crates/cryptography/polynomial/Cargo.toml
@@ -23,7 +23,7 @@ criterion = "0.5.1"
 rand = "0.8.4"
 
 [features]
-tracing = ["dep:tracing", "bls12_381/tracing"]
+tracing = ["dep:tracing"]
 multithreaded = ["maybe_rayon/multithreaded"]
 
 [[bench]]

--- a/crates/eip4844/Cargo.toml
+++ b/crates/eip4844/Cargo.toml
@@ -12,7 +12,6 @@ repository = { workspace = true }
 workspace = true
 
 [dependencies]
-kzg_multi_open = { workspace = true }
 bls12_381 = { workspace = true }
 polynomial = { workspace = true }
 maybe_rayon = { workspace = true }
@@ -20,12 +19,14 @@ hex = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10.8"
-tracing = { version = "0.1.41", default-features = false, features = ["attributes"], optional = true }
+tracing = { version = "0.1.41", default-features = false, features = [
+    "attributes",
+], optional = true }
 
 [features]
-singlethreaded = ["kzg_multi_open/singlethreaded"]
-multithreaded = ["maybe_rayon/multithreaded", "kzg_multi_open/multithreaded"]
-tracing = ["dep:tracing", "bls12_381/tracing", "kzg_multi_open/tracing"]
+singlethreaded = []
+multithreaded = ["maybe_rayon/multithreaded"]
+tracing = ["dep:tracing", "bls12_381/tracing"]
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/crates/eip4844/Cargo.toml
+++ b/crates/eip4844/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tbd"
+name = "eip4844"
 description = "This crate provides an implementation of the cryptography needed for EIP-4844"
 version = { workspace = true }
 authors = { workspace = true }

--- a/crates/eip4844/Cargo.toml
+++ b/crates/eip4844/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "tbd"
+description = "This crate provides an implementation of the cryptography needed for EIP-4844"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+rust-version = { workspace = true }
+repository = { workspace = true }
+
+[lints]
+workspace = true
+
+[dependencies]
+kzg_multi_open = { workspace = true }
+bls12_381 = { workspace = true }
+polynomial = { workspace = true }
+maybe_rayon = { workspace = true }
+hex = { workspace = true }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10.8"
+tracing = { version = "0.1.41", default-features = false, features = ["attributes"], optional = true }
+
+[features]
+singlethreaded = ["kzg_multi_open/singlethreaded"]
+multithreaded = ["maybe_rayon/multithreaded", "kzg_multi_open/multithreaded"]
+tracing = ["dep:tracing", "bls12_381/tracing", "kzg_multi_open/tracing"]
+
+[dev-dependencies]
+criterion = "0.5.1"
+rand = "0.8.4"
+hex = { workspace = true }
+# Serde-yaml has been deprecated, however since we only
+# use it for tests, we will not update it.
+serde_yaml = "0.9.34"
+tracing-subscriber = { version = "0.3.19", features = ["std", "env-filter"] }
+tracing-forest = { version = "0.1.6", features = ["ansi", "smallvec"] }

--- a/crates/eip4844/Cargo.toml
+++ b/crates/eip4844/Cargo.toml
@@ -26,7 +26,7 @@ tracing = { version = "0.1.41", default-features = false, features = [
 [features]
 singlethreaded = []
 multithreaded = ["maybe_rayon/multithreaded"]
-tracing = ["dep:tracing", "bls12_381/tracing"]
+tracing = ["dep:tracing"]
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/crates/eip4844/examples/compute_kzg_proof.rs
+++ b/crates/eip4844/examples/compute_kzg_proof.rs
@@ -1,0 +1,48 @@
+use std::time::Instant;
+
+use bls12_381::{ff::Field, Scalar};
+use eip4844::{
+    constants::{BYTES_PER_BLOB, FIELD_ELEMENTS_PER_BLOB},
+    Context, TrustedSetup,
+};
+use tracing_forest::{util::LevelFilter, ForestLayer};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Registry};
+
+fn dummy_blob() -> [u8; BYTES_PER_BLOB] {
+    let polynomial = (0..FIELD_ELEMENTS_PER_BLOB).map(|i| -Scalar::from(i as u64));
+    let blob: Vec<_> = polynomial
+        .into_iter()
+        .flat_map(|scalar| scalar.to_bytes_be())
+        .collect();
+    blob.try_into().expect("blob conversion failed")
+}
+
+fn main() {
+    let trusted_setup = TrustedSetup::default();
+    let blob = dummy_blob();
+    let z = Scalar::random(rand::thread_rng()).to_bytes_be();
+
+    let ctx = Context::new(&trusted_setup);
+
+    println!("Warming up for 3 seconds...");
+
+    let start = Instant::now();
+    while Instant::now().duration_since(start).as_secs() < 3 {
+        ctx.compute_kzg_proof(&blob, z)
+            .expect("failed to compute kzg proof");
+    }
+
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::INFO.into())
+        .from_env_lossy();
+
+    Registry::default()
+        .with(env_filter)
+        .with(ForestLayer::default())
+        .init();
+
+    ctx.compute_kzg_proof(&blob, z)
+        .expect("failed to compute kzg proof (z out of domain)");
+    ctx.compute_kzg_proof(&blob, (-Scalar::ONE).to_bytes_be())
+        .expect("failed to compute kzg proof (z within domain)");
+}

--- a/crates/eip4844/src/constants.rs
+++ b/crates/eip4844/src/constants.rs
@@ -1,0 +1,23 @@
+// Note: Any mention of field elements in this file and in general in the codebase
+// refers to the scalar field.
+
+/// The number of bytes needed to represent a field element.
+///
+/// Note: This is originally specified in the 4844 specs.
+pub const BYTES_PER_FIELD_ELEMENT: usize = 32;
+
+/// The number of field elements needed to represent a blob.
+///
+/// Note: This is originally specified in the 4844 specs.
+pub const FIELD_ELEMENTS_PER_BLOB: usize = 4096;
+
+/// The number of bytes needed to represent a blob.
+pub const BYTES_PER_BLOB: usize = FIELD_ELEMENTS_PER_BLOB * BYTES_PER_FIELD_ELEMENT;
+
+/// The number of bytes needed to represent a G1 element.
+pub(crate) const BYTES_PER_G1_POINT: usize = 48;
+
+/// The number of bytes needed to represent a commitment.
+///
+/// Note: commitments are G1 elements.
+pub const BYTES_PER_COMMITMENT: usize = BYTES_PER_G1_POINT;

--- a/crates/eip4844/src/cryptography.rs
+++ b/crates/eip4844/src/cryptography.rs
@@ -180,6 +180,8 @@ pub mod prover {
     }
 
     /// Compute evaluation and quotient of the given polynomial at the given point.
+    ///
+    /// Note: The quotient is returned in normal order.
     pub fn compute_evaluation_and_quotient(
         domain: &Domain,
         polynomial: &[Scalar],
@@ -189,12 +191,14 @@ pub mod prover {
         let point_idx = domain.roots.iter().position(|root| *root == z);
 
         // Compute evaluation and quotient.
-        let (z, quotient) = point_idx.map_or_else(
+        let (z, mut quotient) = point_idx.map_or_else(
             || compute_evaluation_and_quotient_out_of_domain(domain, polynomial, z),
             |point_idx| {
                 compute_evaluation_and_quotient_within_domain(domain, polynomial, point_idx)
             },
         );
+
+        bitreverse_slice(&mut quotient);
 
         (z, quotient)
     }

--- a/crates/eip4844/src/cryptography.rs
+++ b/crates/eip4844/src/cryptography.rs
@@ -26,12 +26,17 @@ pub(crate) fn bitreverse_slice<T>(a: &mut [T]) {
 
 pub mod verifier {
 
+    use std::iter::successors;
+
     use bls12_381::{
-        group::Curve, lincomb::g1_lincomb, multi_pairings, G1Point, G2Point, G2Prepared, Scalar,
+        batch_inversion::batch_inverse, ff::Field, group::Curve, lincomb::g1_lincomb,
+        multi_pairings, reduce_bytes_to_scalar_bias, G1Point, G2Point, G2Prepared, Scalar,
     };
     use polynomial::domain::Domain;
+    use sha2::{Digest, Sha256};
 
-    use crate::{trusted_setup::TrustedSetup, VerifierError};
+    use super::bitreverse_slice;
+    use crate::{trusted_setup::TrustedSetup, KZGCommitment, KZGProof, VerifierError};
 
     /// The key that is used to verify KZG single-point opening proofs.
     pub struct VerificationKey {
@@ -143,6 +148,115 @@ pub mod verifier {
                 Err(VerifierError::InvalidProof)
             }
         }
+    }
+
+    /// Compute evaluation of the given polynomial at the given point.
+    pub(crate) fn compute_evaluation(domain: &Domain, polynomial: &[Scalar], z: Scalar) -> Scalar {
+        domain.roots.iter().position(|root| *root == z).map_or_else(
+            || compute_evaluation_out_of_domain(domain, polynomial, z),
+            |position| polynomial[position],
+        )
+    }
+
+    /// Compute evaluation of the given polynomial at the given point.
+    /// The point is guaranteed to be out-of-domain.
+    pub(crate) fn compute_evaluation_out_of_domain(
+        domain: &Domain,
+        polynomial: &[Scalar],
+        z: Scalar,
+    ) -> Scalar {
+        let domain_size = domain.roots.len();
+
+        // Note: This clone is okay because after eip7594, this crate is no longer on the critical path.
+        let mut roots_brp = domain.roots.clone();
+        bitreverse_slice(&mut roots_brp);
+
+        // 1 / (z - ω^i)
+        let mut denoms = roots_brp.iter().map(|root| z - *root).collect::<Vec<_>>();
+        batch_inverse(&mut denoms);
+
+        // \sum (ω^i * f(ω^i) / (z - ω^i)) * ((z^n - 1) / n)
+        let y = roots_brp
+            .iter()
+            .zip(polynomial)
+            .zip(&denoms)
+            .map(|((root, f_root), denom)| root * *f_root * denom)
+            .sum::<Scalar>()
+            * (z.pow_vartime([domain_size as u64]) - Scalar::ONE)
+            * domain.domain_size_inv;
+
+        y
+    }
+
+    /// Compute random linear combination challenge scalars for batch verification.
+    ///
+    /// The matching function in the specs is: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#verify_kzg_proof_batch
+    pub fn compute_r_powers_for_verify_kzg_proof_batch(
+        domain_size: usize,
+        commitments: &[KZGCommitment],
+        zs: &[Scalar],
+        ys: &[Scalar],
+        proofs: &[KZGProof],
+    ) -> Vec<Scalar> {
+        use bls12_381::ff::PrimeField;
+
+        let bytes_per_commitment = G1Point::compressed_size();
+        let bytes_per_field_element = Scalar::NUM_BITS.div_ceil(8) as usize;
+
+        // DomSepProtocol is a Domain Separator to identify the protocol.
+        //
+        // It matches [RANDOM_CHALLENGE_KZG_BATCH_DOMAIN] in the spec.
+        //
+        // [RANDOM_CHALLENGE_KZG_BATCH_DOMAIN]: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#blob
+        const DOMAIN_SEP: &str = "RCKZGBATCH___V1_";
+
+        let n = commitments.len();
+
+        let hash_input_size = DOMAIN_SEP.len()
+        + size_of::<u64>() // polynomial bound
+        + size_of::<u64>() // batch size
+        + n * (
+            bytes_per_commitment // commitment
+            + bytes_per_field_element // z 
+            + bytes_per_field_element // y
+            + bytes_per_commitment // proof
+        );
+
+        let mut hash_input: Vec<u8> = Vec::with_capacity(hash_input_size);
+
+        hash_input.extend(DOMAIN_SEP.as_bytes());
+        hash_input.extend((domain_size as u64).to_be_bytes());
+        hash_input.extend((n as u64).to_be_bytes());
+        commitments
+            .iter()
+            .zip(zs)
+            .zip(ys)
+            .zip(proofs)
+            .for_each(|(((commitment, z), y), proof)| {
+                hash_input.extend(commitment);
+                hash_input.extend(z.to_bytes_be());
+                hash_input.extend(y.to_bytes_be());
+                hash_input.extend(proof);
+            });
+
+        assert_eq!(hash_input.len(), hash_input_size);
+        let mut hasher = Sha256::new();
+        hasher.update(hash_input);
+        let result: [u8; 32] = hasher.finalize().into();
+
+        // For randomization, we only need a 128 bit scalar, since this is used for batch verification.
+        // See for example, the randomizers section in : https://cr.yp.to/badbatch/badbatch-20120919.pdf
+        //
+        // This is noted because when we convert a 256 bit hash to a scalar, a bias will be introduced.
+        // This however does not affect our security guarantees because the bias is negligible given we
+        // want a uniformly random 128 bit integer.
+        //
+        // Also there is a negligible probably that the scalar is zero, so we do not handle this case here.
+        let r = reduce_bytes_to_scalar_bias(result);
+
+        successors(Some(Scalar::ONE), |power| Some(*power * r))
+            .take(n)
+            .collect()
     }
 }
 

--- a/crates/eip4844/src/cryptography.rs
+++ b/crates/eip4844/src/cryptography.rs
@@ -1,0 +1,322 @@
+pub(crate) fn bitreverse(mut n: u32, l: u32) -> u32 {
+    let mut r = 0;
+    for _ in 0..l {
+        r = (r << 1) | (n & 1);
+        n >>= 1;
+    }
+    r
+}
+
+pub(crate) fn bitreverse_slice<T>(a: &mut [T]) {
+    if a.is_empty() {
+        return;
+    }
+
+    let n = a.len();
+    let log_n = n.ilog2();
+    assert_eq!(n, 1 << log_n);
+
+    for k in 0..n {
+        let rk = bitreverse(k as u32, log_n) as usize;
+        if k < rk {
+            a.swap(rk, k);
+        }
+    }
+}
+
+pub mod verifier {
+    use std::iter::successors;
+
+    use bls12_381::{
+        batch_inversion::batch_inverse, ff::Field, group::Curve, lincomb::g1_lincomb,
+        multi_pairings, reduce_bytes_to_scalar_bias, G1Point, G2Point, G2Prepared, Scalar,
+    };
+    use polynomial::domain::Domain;
+    use sha2::{Digest, Sha256};
+
+    use crate::{
+        constants::{
+            BYTES_PER_BLOB, BYTES_PER_COMMITMENT, BYTES_PER_FIELD_ELEMENT, FIELD_ELEMENTS_PER_BLOB,
+        },
+        serialization::{
+            deserialize_blob_to_scalars, deserialize_bytes_to_scalar, deserialize_compressed_g1,
+        },
+        trusted_setup::{
+            deserialize_g1_points, deserialize_g2_points, SubgroupCheck, TrustedSetup,
+        },
+        BlobRef, Context, Error, KZGCommitment, KZGOpeningEvaluation, KZGOpeningPoint, KZGProof,
+        VerifierError,
+    };
+
+    /// The key that is used to verify KZG single-point opening proofs.
+    pub struct VerificationKey {
+        pub gen_g1: G1Point,
+        pub gen_g2: G2Point,
+        pub tau_g2: G2Point,
+    }
+
+    pub struct Verifier {
+        /// Domain used to create the opening proofs.
+        pub domain: Domain,
+        /// Verification key used to verify KZG single-point opening proofs.
+        pub verification_key: VerificationKey,
+    }
+
+    impl Verifier {
+        pub fn new(domain_size: usize, trusted_setup: &TrustedSetup) -> Self {
+            Self {
+                domain: Domain::new(domain_size),
+                verification_key: VerificationKey::from(trusted_setup),
+            }
+        }
+
+        pub fn verify_kzg_proof(
+            &self,
+            commitment: G1Point,
+            z: Scalar,
+            y: Scalar,
+            proof: G1Point,
+        ) -> Result<(), VerifierError> {
+            let vk = &self.verification_key;
+
+            // [f(τ) - f(z)]G₁
+            let commitment_minus_z = (commitment - vk.gen_g1 * y).into();
+
+            // [-1]G₂
+            let neg_gen_g2 = G2Prepared::from(-vk.gen_g2);
+
+            // [τ - z]G₂
+            let tau_minus_challenge_g2 = G2Prepared::from((vk.tau_g2 - vk.gen_g2 * z).to_affine());
+
+            // Check whether `f(X) - f(z) == q(X) * (X - z)`
+            let proof_valid = multi_pairings(&[
+                (&commitment_minus_z, &neg_gen_g2),
+                (&proof, &tau_minus_challenge_g2),
+            ]);
+            if proof_valid {
+                Ok(())
+            } else {
+                Err(VerifierError::InvalidProof)
+            }
+        }
+
+        pub fn verify_kzg_proof_batch(
+            &self,
+            commitments: &[G1Point],
+            zs: &[Scalar],
+            ys: &[Scalar],
+            proofs: &[G1Point],
+            r_powers: &[Scalar],
+        ) -> Result<(), VerifierError> {
+            assert!(
+                commitments.len() == zs.len()
+                    && commitments.len() == ys.len()
+                    && commitments.len() == proofs.len()
+                    && commitments.len() == r_powers.len()
+            );
+
+            let vk = &self.verification_key;
+
+            // \sum r^i * [f_i(τ)] - (\sum r^i * y_i) * [1] + \sum r^i * z_i * [q(τ)]
+            let lhs_g1 = {
+                let points = commitments
+                    .iter()
+                    .chain(proofs)
+                    .chain([&vk.gen_g1])
+                    .copied()
+                    .collect::<Vec<_>>();
+                let scalars = r_powers
+                    .iter()
+                    .copied()
+                    .chain(r_powers.iter().zip(zs).map(|(r_i, z_i)| *r_i * z_i))
+                    .chain([-r_powers
+                        .iter()
+                        .zip(ys)
+                        .map(|(r_i, y_i)| *r_i * y_i)
+                        .sum::<Scalar>()])
+                    .collect::<Vec<_>>();
+                g1_lincomb(&points, &scalars)
+                    .expect("points and scalars have same length")
+                    .into()
+            };
+
+            // \sum r^i * [q(τ)]
+            let rhs_g1 = g1_lincomb(proofs, r_powers)
+                .expect("points and scalars have same length")
+                .into();
+
+            // [-1]G₂
+            let lhs_g2 = G2Prepared::from(-vk.gen_g2);
+
+            // [τ]G₂
+            let rhs_g2 = G2Prepared::from(vk.tau_g2);
+
+            let proof_valid = multi_pairings(&[(&lhs_g1, &lhs_g2), (&rhs_g1, &rhs_g2)]);
+            if proof_valid {
+                Ok(())
+            } else {
+                Err(VerifierError::InvalidProof)
+            }
+        }
+    }
+}
+
+pub mod prover {
+    use bls12_381::{
+        batch_inversion::batch_inverse, ff::Field, lincomb::g1_lincomb, G1Point, Scalar,
+    };
+    use maybe_rayon::prelude::*;
+    use polynomial::domain::Domain;
+
+    use crate::{
+        constants::FIELD_ELEMENTS_PER_BLOB,
+        cryptography::{bitreverse, bitreverse_slice},
+        serialization::{
+            deserialize_blob_to_scalars, deserialize_bytes_to_scalar, deserialize_compressed_g1,
+            serialize_g1_compressed,
+        },
+        trusted_setup::{deserialize_g1_points, SubgroupCheck},
+        verifier::compute_fiat_shamir_challenge,
+        BlobRef, Context, Error, KZGCommitment, KZGOpeningEvaluation, KZGOpeningPoint, KZGProof,
+        TrustedSetup,
+    };
+
+    /// The key that is used to commit to polynomials in lagrange form (bit-reversed
+    /// order)
+    pub struct CommitKey {
+        pub g1_lagrange: Vec<G1Point>,
+    }
+
+    pub struct Prover {
+        /// Domain used to create the opening proofs.
+        pub domain: Domain,
+        /// Commitment key used for committing to the polynomial
+        /// in lagrange form
+        pub commit_key: CommitKey,
+    }
+
+    impl Prover {
+        pub fn new(domain_size: usize, trusted_setup: &TrustedSetup) -> Self {
+            Self {
+                domain: Domain::new(domain_size),
+                commit_key: CommitKey::from(trusted_setup),
+            }
+        }
+    }
+
+    /// Compute evaluation and quotient of the given polynomial at the given point.
+    pub fn compute_evaluation_and_quotient(
+        domain: &Domain,
+        polynomial: &[Scalar],
+        z: Scalar,
+    ) -> (Scalar, Vec<Scalar>) {
+        // Find the index of point if it's in the domain.
+        let point_idx = domain.roots.iter().position(|root| *root == z);
+
+        // Compute evaluation and quotient.
+        let (z, quotient) = point_idx.map_or_else(
+            || compute_evaluation_and_quotient_out_of_domain(domain, polynomial, z),
+            |point_idx| {
+                compute_evaluation_and_quotient_within_domain(domain, polynomial, point_idx)
+            },
+        );
+
+        (z, quotient)
+    }
+
+    /// Compute evaluation and quotient of the given polynomial at the given point.
+    /// The point is guaranteed to be out-of-domain.
+    pub fn compute_evaluation_and_quotient_out_of_domain(
+        domain: &Domain,
+        polynomial: &[Scalar],
+        z: Scalar,
+    ) -> (Scalar, Vec<Scalar>) {
+        let mut roots_brp = domain.roots.clone();
+        bitreverse_slice(&mut roots_brp);
+
+        // 1 / (z - ω^i)
+        let mut denoms = roots_brp.iter().map(|root| z - *root).collect::<Vec<_>>();
+        batch_inverse(&mut denoms);
+
+        // \sum (ω^i * f(ω^i) / (z - ω^i)) * ((z^n - 1) / n)
+        let y = roots_brp
+            .maybe_into_par_iter()
+            .zip(polynomial)
+            .zip(&denoms)
+            .map(|((root, f_root), denom)| root * *f_root * denom)
+            .sum::<Scalar>()
+            * (z.pow_vartime([FIELD_ELEMENTS_PER_BLOB as u64]) - Scalar::ONE)
+            * domain.domain_size_inv;
+
+        // (y - f(ω^i)) / (z - ω^i)
+        let quotient = denoms
+            .maybe_into_par_iter()
+            .zip(polynomial)
+            .map(|(denom, f_root)| (y - *f_root) * denom)
+            .collect();
+
+        (y, quotient)
+    }
+
+    /// Compute evaluation and quotient of the given polynomial at the given point
+    /// index of the domain.
+    ///
+    /// For more details, read [PCS multiproofs using random evaluation] section
+    /// "Dividing when one of the points is zero".
+    ///
+    /// The matching function in the specs is: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#compute_quotient_eval_within_domain
+    ///
+    /// [PCS multiproofs using random evaluation]: https://dankradfeist.de/ethereum/2021/06/18/pcs-multiproofs.html
+    pub fn compute_evaluation_and_quotient_within_domain(
+        domain: &Domain,
+        polynomial: &[Scalar],
+        point_idx: usize,
+    ) -> (Scalar, Vec<Scalar>) {
+        // ω^m
+        let z = domain.roots[point_idx];
+        // ω^(n-m)
+        let z_inv = domain.roots[(FIELD_ELEMENTS_PER_BLOB - point_idx) % FIELD_ELEMENTS_PER_BLOB];
+
+        // Because polynomial is in bit-reversed order, and we need to compute
+        // quotient also in bit-reversed order, so we work with bit-reversed point
+        // index from now on.
+        let point_idx_brp = bitreverse(point_idx as u32, FIELD_ELEMENTS_PER_BLOB.ilog2()) as usize;
+
+        // Root in bit-reversed order.
+        let mut roots_brp = domain.roots.clone();
+        bitreverse_slice(&mut roots_brp);
+
+        // f(ω^m)
+        let y = polynomial[point_idx_brp];
+
+        // 1 / (ω^m - ω^j)
+        // Note that we set (ω^m - ω^m) to be one to make the later `batch_inverse` work.
+        let mut denoms = (&roots_brp)
+            .maybe_into_par_iter()
+            .enumerate()
+            .map(|(idx, root)| {
+                (idx == point_idx_brp)
+                    .then_some(Scalar::ONE)
+                    .unwrap_or_else(|| z - root)
+            })
+            .collect::<Vec<_>>();
+        batch_inverse(&mut denoms);
+
+        // (f(ω^m) - f(ω^j)) / (ω^m - ω^j)
+        let mut quotient = denoms
+            .maybe_into_par_iter()
+            .zip(polynomial)
+            .map(|(denom, f_root)| (y - f_root) * denom)
+            .collect::<Vec<_>>();
+
+        // Compute q(ω^m) = \sum q(ω^j) * (A'(ω_m) / A'(ω_j)) = \sum q(ω^j) * (ω_j / ω_m)
+        quotient[point_idx_brp] = Scalar::ZERO;
+        quotient[point_idx_brp] = -roots_brp
+            .maybe_into_par_iter()
+            .zip(&quotient)
+            .map(|(root, quotient)| *quotient * root * z_inv)
+            .sum::<Scalar>();
+
+        (y, quotient)
+    }
+}

--- a/crates/eip4844/src/cryptography.rs
+++ b/crates/eip4844/src/cryptography.rs
@@ -1,3 +1,11 @@
+use bls12_381::{reduce_bytes_to_scalar_bias, Scalar};
+use sha2::{Digest, Sha256};
+
+use crate::{
+    constants::{BYTES_PER_BLOB, BYTES_PER_COMMITMENT, FIELD_ELEMENTS_PER_BLOB},
+    BlobRef, KZGCommitment,
+};
+
 pub(crate) fn bitreverse(mut n: u32, l: u32) -> u32 {
     let mut r = 0;
     for _ in 0..l {
@@ -22,6 +30,54 @@ pub(crate) fn bitreverse_slice<T>(a: &mut [T]) {
             a.swap(rk, k);
         }
     }
+}
+
+/// Compute Fiat-Shamir challenge of a blob KZG proof.
+///
+/// The matching function in the specs is: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#compute_challenge
+pub(crate) fn compute_fiat_shamir_challenge(blob: BlobRef, commitment: KZGCommitment) -> Scalar {
+    // DomSepProtocol is a Domain Separator to identify the protocol.
+    //
+    // It matches [FIAT_SHAMIR_PROTOCOL_DOMAIN] in the spec.
+    //
+    // [FIAT_SHAMIR_PROTOCOL_DOMAIN]: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#blob
+    const DOMAIN_SEP: &str = "FSBLOBVERIFY_V1_";
+
+    let hash_input_size = DOMAIN_SEP.len()
+            + 2 * size_of::<u64>() // polynomial bound
+            + BYTES_PER_BLOB // blob
+            + BYTES_PER_COMMITMENT // commitment
+            ;
+
+    let mut hash_input: Vec<u8> = Vec::with_capacity(hash_input_size);
+
+    hash_input.extend(DOMAIN_SEP.as_bytes());
+    hash_input.extend(u64_to_byte_array_16(FIELD_ELEMENTS_PER_BLOB as u64));
+    hash_input.extend(blob);
+    hash_input.extend(commitment);
+
+    assert_eq!(hash_input.len(), hash_input_size);
+    let mut hasher = Sha256::new();
+    hasher.update(hash_input);
+    let result: [u8; 32] = hasher.finalize().into();
+
+    // For randomization, we only need a 128 bit scalar, since this is used for batch verification.
+    // See for example, the randomizers section in : https://cr.yp.to/badbatch/badbatch-20120919.pdf
+    //
+    // This is noted because when we convert a 256 bit hash to a scalar, a bias will be introduced.
+    // This however does not affect our security guarantees because the bias is negligible given we
+    // want a uniformly random 128 bit integer.
+    //
+    // Also there is a negligible probably that the scalar is zero, so we do not handle this case here.
+    reduce_bytes_to_scalar_bias(result)
+}
+
+/// Converts a u64 to a byte array of length 16 in big endian format.
+/// This implies that the first 8 bytes of the result are always 0.
+fn u64_to_byte_array_16(number: u64) -> [u8; 16] {
+    let mut bytes = [0; 16];
+    bytes[8..].copy_from_slice(&number.to_be_bytes());
+    bytes
 }
 
 pub mod verifier {

--- a/crates/eip4844/src/cryptography.rs
+++ b/crates/eip4844/src/cryptography.rs
@@ -380,6 +380,7 @@ pub mod prover {
 
     /// Compute evaluation and quotient of the given polynomial at the given point.
     /// The point is guaranteed to be out-of-domain.
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     pub fn compute_evaluation_and_quotient_out_of_domain(
         domain: &Domain,
         polynomial: &[Scalar],
@@ -427,6 +428,7 @@ pub mod prover {
     /// The matching function in the specs is: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#compute_quotient_eval_within_domain
     ///
     /// [PCS multiproofs using random evaluation]: https://dankradfeist.de/ethereum/2021/06/18/pcs-multiproofs.html
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     pub fn compute_evaluation_and_quotient_within_domain(
         domain: &Domain,
         polynomial: &[Scalar],

--- a/crates/eip4844/src/errors.rs
+++ b/crates/eip4844/src/errors.rs
@@ -1,30 +1,21 @@
 /// Errors that can occur either during proving, verification or serialization.
 #[derive(Debug)]
 pub enum Error {
-    Prover(ProverError),
     Verifier(VerifierError),
     Serialization(SerializationError),
 }
 
-impl From<ProverError> for Error {
-    fn from(value: ProverError) -> Self {
-        Self::Prover(value)
-    }
-}
 impl From<VerifierError> for Error {
     fn from(value: VerifierError) -> Self {
         Self::Verifier(value)
     }
 }
+
 impl From<SerializationError> for Error {
     fn from(value: SerializationError) -> Self {
         Self::Serialization(value)
     }
 }
-
-/// Errors that can occur while calling a method in the Prover API
-#[derive(Debug)]
-pub enum ProverError {}
 
 /// Errors that can occur while calling a method in the Verifier API
 #[derive(Debug)]

--- a/crates/eip4844/src/errors.rs
+++ b/crates/eip4844/src/errors.rs
@@ -1,0 +1,49 @@
+/// Errors that can occur either during proving, verification or serialization.
+#[derive(Debug)]
+pub enum Error {
+    Prover(ProverError),
+    Verifier(VerifierError),
+    Serialization(SerializationError),
+}
+
+impl From<ProverError> for Error {
+    fn from(value: ProverError) -> Self {
+        Self::Prover(value)
+    }
+}
+impl From<VerifierError> for Error {
+    fn from(value: VerifierError) -> Self {
+        Self::Verifier(value)
+    }
+}
+impl From<SerializationError> for Error {
+    fn from(value: SerializationError) -> Self {
+        Self::Serialization(value)
+    }
+}
+
+/// Errors that can occur while calling a method in the Prover API
+#[derive(Debug)]
+pub enum ProverError {}
+
+/// Errors that can occur while calling a method in the Verifier API
+#[derive(Debug)]
+pub enum VerifierError {
+    InvalidProof,
+    BatchVerificationInputsMustHaveSameLength {
+        blobs_len: usize,
+        commitments_len: usize,
+        proofs_len: usize,
+    },
+}
+
+/// Errors that can occur during deserialization of untrusted input from the public API
+/// or the trusted setup.
+#[derive(Debug)]
+pub enum SerializationError {
+    CouldNotDeserializeScalar { bytes: Vec<u8> },
+    CouldNotDeserializeG1Point { bytes: Vec<u8> },
+    ScalarHasInvalidLength { bytes: Vec<u8>, length: usize },
+    BlobHasInvalidLength { bytes: Vec<u8>, length: usize },
+    G1PointHasInvalidLength { bytes: Vec<u8>, length: usize },
+}

--- a/crates/eip4844/src/lib.rs
+++ b/crates/eip4844/src/lib.rs
@@ -1,0 +1,67 @@
+use constants::{BYTES_PER_BLOB, BYTES_PER_CELL, BYTES_PER_COMMITMENT, BYTES_PER_FIELD_ELEMENT};
+
+mod errors;
+mod prover;
+mod verifier;
+
+#[allow(dead_code)]
+#[path = "../../eip7594/src/constants.rs"]
+pub mod constants;
+#[allow(dead_code)]
+#[path = "../../eip7594/src/serialization.rs"]
+mod serialization;
+#[allow(dead_code)]
+#[path = "../../eip7594/src/trusted_setup.rs"]
+mod trusted_setup;
+
+pub use errors::{Error, ProverError, SerializationError, VerifierError};
+use prover::Prover;
+pub use trusted_setup::TrustedSetup;
+use verifier::Verifier;
+
+/// BlobRef denotes a references to an opaque Blob.
+///
+/// Note: This library never returns a Blob, which is why we
+/// do not have a Blob type.
+pub type BlobRef<'a> = &'a [u8; BYTES_PER_BLOB];
+
+/// KZGCommitment denotes a 48 byte commitment to a polynomial f(x)
+/// that we would like to make and verify opening proofs about.
+pub type KZGCommitment = [u8; BYTES_PER_COMMITMENT];
+
+// TODO: Remove me.
+pub type Cell = Box<[u8; BYTES_PER_CELL]>;
+
+/// KZGProof denotes a 48 byte commitment to a polynomial
+/// that one can use to prove that a polynomial f(x) was
+/// correctly evaluated on a coset `H` and returned a set of points.
+pub type KZGProof = [u8; BYTES_PER_COMMITMENT];
+
+/// KZGOpeningPoint denotes a 32 byte of a scalar to be evaluated at.
+pub type KZGOpeningPoint = [u8; BYTES_PER_FIELD_ELEMENT];
+
+/// KZGOpeningEvaluation denotes a 32 byte of a scalar that evaluated at certain
+/// point.
+pub type KZGOpeningEvaluation = [u8; BYTES_PER_FIELD_ELEMENT];
+
+pub struct Context {
+    prover: Prover,
+    verifier: Verifier,
+}
+
+impl Default for Context {
+    fn default() -> Self {
+        let trusted_setup = TrustedSetup::default();
+
+        Self::new(&trusted_setup)
+    }
+}
+
+impl Context {
+    pub fn new(trusted_setup: &TrustedSetup) -> Self {
+        Self {
+            prover: Prover::new(trusted_setup),
+            verifier: Verifier::new(trusted_setup),
+        }
+    }
+}

--- a/crates/eip4844/src/lib.rs
+++ b/crates/eip4844/src/lib.rs
@@ -1,17 +1,20 @@
-use constants::{BYTES_PER_BLOB, BYTES_PER_COMMITMENT, BYTES_PER_FIELD_ELEMENT};
+use constants::{
+    BYTES_PER_BLOB, BYTES_PER_COMMITMENT, BYTES_PER_FIELD_ELEMENT, FIELD_ELEMENTS_PER_BLOB,
+};
 
 mod errors;
 mod prover;
-mod verifier;
+pub(crate) mod verifier;
 
 pub mod constants;
+mod cryptography;
 mod serialization;
 mod trusted_setup;
 
 pub use errors::{Error, ProverError, SerializationError, VerifierError};
-use prover::Prover;
 pub use trusted_setup::TrustedSetup;
-use verifier::Verifier;
+
+use crate::cryptography::{prover::Prover, verifier::Verifier};
 
 /// BlobRef denotes a references to an opaque Blob.
 ///
@@ -51,8 +54,8 @@ impl Default for Context {
 impl Context {
     pub fn new(trusted_setup: &TrustedSetup) -> Self {
         Self {
-            prover: Prover::new(trusted_setup),
-            verifier: Verifier::new(trusted_setup),
+            prover: Prover::new(FIELD_ELEMENTS_PER_BLOB, trusted_setup),
+            verifier: Verifier::new(FIELD_ELEMENTS_PER_BLOB, trusted_setup),
         }
     }
 }

--- a/crates/eip4844/src/lib.rs
+++ b/crates/eip4844/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(all(feature = "singlethreaded", feature = "multithreaded"))]
+compile_error!("`singlethreaded` and `multithreaded` cannot be enabled simultaneously");
+
 use constants::{
     BYTES_PER_BLOB, BYTES_PER_COMMITMENT, BYTES_PER_FIELD_ELEMENT, FIELD_ELEMENTS_PER_BLOB,
 };

--- a/crates/eip4844/src/lib.rs
+++ b/crates/eip4844/src/lib.rs
@@ -14,7 +14,7 @@ mod cryptography;
 mod serialization;
 mod trusted_setup;
 
-pub use errors::{Error, ProverError, SerializationError, VerifierError};
+pub use errors::{Error, SerializationError, VerifierError};
 pub use trusted_setup::TrustedSetup;
 
 use crate::cryptography::{prover::Prover, verifier::Verifier};

--- a/crates/eip4844/src/lib.rs
+++ b/crates/eip4844/src/lib.rs
@@ -1,17 +1,11 @@
-use constants::{BYTES_PER_BLOB, BYTES_PER_CELL, BYTES_PER_COMMITMENT, BYTES_PER_FIELD_ELEMENT};
+use constants::{BYTES_PER_BLOB, BYTES_PER_COMMITMENT, BYTES_PER_FIELD_ELEMENT};
 
 mod errors;
 mod prover;
 mod verifier;
 
-#[allow(dead_code)]
-#[path = "../../eip7594/src/constants.rs"]
 pub mod constants;
-#[allow(dead_code)]
-#[path = "../../eip7594/src/serialization.rs"]
 mod serialization;
-#[allow(dead_code)]
-#[path = "../../eip7594/src/trusted_setup.rs"]
 mod trusted_setup;
 
 pub use errors::{Error, ProverError, SerializationError, VerifierError};
@@ -28,9 +22,6 @@ pub type BlobRef<'a> = &'a [u8; BYTES_PER_BLOB];
 /// KZGCommitment denotes a 48 byte commitment to a polynomial f(x)
 /// that we would like to make and verify opening proofs about.
 pub type KZGCommitment = [u8; BYTES_PER_COMMITMENT];
-
-// TODO: Remove me.
-pub type Cell = Box<[u8; BYTES_PER_CELL]>;
 
 /// KZGProof denotes a 48 byte commitment to a polynomial
 /// that one can use to prove that a polynomial f(x) was

--- a/crates/eip4844/src/prover.rs
+++ b/crates/eip4844/src/prover.rs
@@ -1,0 +1,238 @@
+use bls12_381::{batch_inversion::batch_inverse, ff::Field, lincomb::g1_lincomb, G1Point, Scalar};
+use maybe_rayon::prelude::*;
+use polynomial::domain::Domain;
+
+use crate::{
+    constants::FIELD_ELEMENTS_PER_BLOB,
+    serialization::{
+        deserialize_blob_to_scalars, deserialize_bytes_to_scalar, deserialize_compressed_g1,
+        serialize_g1_compressed,
+    },
+    trusted_setup::{deserialize_g1_points, SubgroupCheck},
+    verifier::{bitreverse, bitreverse_slice, compute_fiat_shamir_challenge},
+    BlobRef, Context, Error, KZGCommitment, KZGOpeningEvaluation, KZGOpeningPoint, KZGProof,
+    TrustedSetup,
+};
+
+/// The key that is used to commit to polynomials in lagrange form (bit-reversed
+/// order)
+pub struct CommitKey {
+    g1_lagrange_brp: Vec<G1Point>,
+}
+
+impl From<&TrustedSetup> for CommitKey {
+    fn from(setup: &TrustedSetup) -> Self {
+        let mut g1_lagrange_brp = deserialize_g1_points(&setup.g1_lagrange, SubgroupCheck::NoCheck);
+        bitreverse_slice(&mut g1_lagrange_brp);
+        Self { g1_lagrange_brp }
+    }
+}
+
+pub struct Prover {
+    /// Domain used to create the opening proofs.
+    domain: Domain,
+    /// Commitment key used for committing to the polynomial
+    /// in lagrange form (bit-reversed order).
+    commit_key: CommitKey,
+}
+
+impl Prover {
+    pub fn new(trusted_setup: &TrustedSetup) -> Self {
+        Self {
+            domain: Domain::new(FIELD_ELEMENTS_PER_BLOB),
+            commit_key: CommitKey::from(trusted_setup),
+        }
+    }
+}
+
+impl Context {
+    /// Computes the KZG commitment to the polynomial represented by the blob.
+    ///
+    /// The matching function in the specs is: https://github.com/ethereum/consensus-specs/blob/13ac373a2c284dc66b48ddd2ef0a10537e4e0de6/specs/deneb/polynomial-commitments.md#blob_to_kzg_commitment
+    pub fn blob_to_kzg_commitment(&self, blob: BlobRef) -> Result<KZGCommitment, Error> {
+        // Deserialize the blob into scalars.
+        let polynomial = deserialize_blob_to_scalars(blob)?;
+
+        // Compute commitment in lagrange form.
+        let commitment = g1_lincomb(&self.prover.commit_key.g1_lagrange_brp, &polynomial)
+            .expect("number of g1 points is equal to the number of coefficients in the polynomial")
+            .into();
+
+        // Serialize the commitment.
+        Ok(serialize_g1_compressed(&commitment))
+    }
+
+    /// Compute the KZG proof given a blob and a point.
+    ///
+    /// The matching function in the specs is: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#compute_kzg_proof
+    pub fn compute_kzg_proof(
+        &self,
+        blob: BlobRef,
+        z: KZGOpeningPoint,
+    ) -> Result<(KZGProof, KZGOpeningEvaluation), Error> {
+        // Deserialize the blob into scalars.
+        let polynomial = deserialize_blob_to_scalars(blob)?;
+
+        // Deserialize the point into scalar.
+        let z = deserialize_bytes_to_scalar(&z)?;
+
+        // Compute evaluation and quotient at challenge.
+        let (y, quotient) = compute_evaluation_and_quotient(&self.prover.domain, &polynomial, z);
+
+        // Compute KZG opening proof.
+        let proof = g1_lincomb(&self.prover.commit_key.g1_lagrange_brp, &quotient)
+            .expect("number of g1 points is equal to the number of coefficients in the polynomial")
+            .into();
+
+        // Serialize the commitment.
+        Ok((serialize_g1_compressed(&proof), y.to_bytes_be()))
+    }
+
+    /// Compute the KZG proof given a blob and its corresponding commitment.
+    ///
+    /// Note: This method does not check that the commitment corresponds to the
+    /// blob. The method does still check that the commitment is a valid
+    /// commitment.
+    ///
+    /// The matching function in the specs is: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#compute_kzg_proof
+    pub fn compute_blob_kzg_proof(
+        &self,
+        blob: BlobRef,
+        commitment: KZGCommitment,
+    ) -> Result<KZGProof, Error> {
+        // Deserialize the blob into scalars.
+        let polynomial = deserialize_blob_to_scalars(blob)?;
+
+        // Deserialize the KZG commitment.
+        // We only do this to check if it is in the correct subgroup
+        let _ = deserialize_compressed_g1(&commitment)?;
+
+        // Compute Fiat-Shamir challenge
+        let z = compute_fiat_shamir_challenge(blob, commitment);
+
+        // Compute evaluation and quotient at z.
+        let (_, quotient) = compute_evaluation_and_quotient(&self.prover.domain, &polynomial, z);
+
+        // Compute KZG opening proof.
+        let proof = g1_lincomb(&self.prover.commit_key.g1_lagrange_brp, &quotient)
+            .expect("number of g1 points is equal to the number of coefficients in the polynomial")
+            .into();
+
+        // Serialize the commitment.
+        Ok(serialize_g1_compressed(&proof))
+    }
+}
+
+/// Compute evaluation and quotient of the given polynomial at the given point.
+fn compute_evaluation_and_quotient(
+    domain: &Domain,
+    polynomial: &[Scalar],
+    z: Scalar,
+) -> (Scalar, Vec<Scalar>) {
+    // Find the index of point if it's in the domain.
+    let point_idx = domain.roots.iter().position(|root| *root == z);
+
+    // Compute evaluation and quotient.
+    let (z, quotient) = point_idx.map_or_else(
+        || compute_evaluation_and_quotient_out_of_domain(domain, polynomial, z),
+        |point_idx| compute_evaluation_and_quotient_within_domain(domain, polynomial, point_idx),
+    );
+
+    (z, quotient)
+}
+
+/// Compute evaluation and quotient of the given polynomial at the given point.
+/// The point is guaranteed to be out-of-domain.
+fn compute_evaluation_and_quotient_out_of_domain(
+    domain: &Domain,
+    polynomial: &[Scalar],
+    z: Scalar,
+) -> (Scalar, Vec<Scalar>) {
+    let mut roots_brp = domain.roots.clone();
+    bitreverse_slice(&mut roots_brp);
+
+    // 1 / (z - ω^i)
+    let mut denoms = roots_brp.iter().map(|root| z - *root).collect::<Vec<_>>();
+    batch_inverse(&mut denoms);
+
+    // \sum (ω^i * f(ω^i) / (z - ω^i)) * ((z^n - 1) / n)
+    let y = roots_brp
+        .maybe_into_par_iter()
+        .zip(polynomial)
+        .zip(&denoms)
+        .map(|((root, f_root), denom)| root * *f_root * denom)
+        .sum::<Scalar>()
+        * (z.pow_vartime([FIELD_ELEMENTS_PER_BLOB as u64]) - Scalar::ONE)
+        * domain.domain_size_inv;
+
+    // (y - f(ω^i)) / (z - ω^i)
+    let quotient = denoms
+        .maybe_into_par_iter()
+        .zip(polynomial)
+        .map(|(denom, f_root)| (y - *f_root) * denom)
+        .collect();
+
+    (y, quotient)
+}
+
+/// Compute evaluation and quotient of the given polynomial at the given point
+/// index of the domain.
+///
+/// For more details, read [PCS multiproofs using random evaluation] section
+/// "Dividing when one of the points is zero".
+///
+/// The matching function in the specs is: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#compute_quotient_eval_within_domain
+///
+/// [PCS multiproofs using random evaluation]: https://dankradfeist.de/ethereum/2021/06/18/pcs-multiproofs.html
+fn compute_evaluation_and_quotient_within_domain(
+    domain: &Domain,
+    polynomial: &[Scalar],
+    point_idx: usize,
+) -> (Scalar, Vec<Scalar>) {
+    // ω^m
+    let z = domain.roots[point_idx];
+    // ω^(n-m)
+    let z_inv = domain.roots[(FIELD_ELEMENTS_PER_BLOB - point_idx) % FIELD_ELEMENTS_PER_BLOB];
+
+    // Because polynomial is in bit-reversed order, and we need to compute
+    // quotient also in bit-reversed order, so we work with bit-reversed point
+    // index from now on.
+    let point_idx_brp = bitreverse(point_idx as u32, FIELD_ELEMENTS_PER_BLOB.ilog2()) as usize;
+
+    // Root in bit-reversed order.
+    let mut roots_brp = domain.roots.clone();
+    bitreverse_slice(&mut roots_brp);
+
+    // f(ω^m)
+    let y = polynomial[point_idx_brp];
+
+    // 1 / (ω^m - ω^j)
+    // Note that we set (ω^m - ω^m) to be one to make the later `batch_inverse` work.
+    let mut denoms = (&roots_brp)
+        .maybe_into_par_iter()
+        .enumerate()
+        .map(|(idx, root)| {
+            (idx == point_idx_brp)
+                .then_some(Scalar::ONE)
+                .unwrap_or_else(|| z - root)
+        })
+        .collect::<Vec<_>>();
+    batch_inverse(&mut denoms);
+
+    // (f(ω^m) - f(ω^j)) / (ω^m - ω^j)
+    let mut quotient = denoms
+        .maybe_into_par_iter()
+        .zip(polynomial)
+        .map(|(denom, f_root)| (y - f_root) * denom)
+        .collect::<Vec<_>>();
+
+    // Compute q(ω^m) = \sum q(ω^j) * (A'(ω_m) / A'(ω_j)) = \sum q(ω^j) * (ω_j / ω_m)
+    quotient[point_idx_brp] = Scalar::ZERO;
+    quotient[point_idx_brp] = -roots_brp
+        .maybe_into_par_iter()
+        .zip(&quotient)
+        .map(|(root, quotient)| *quotient * root * z_inv)
+        .sum::<Scalar>();
+
+    (y, quotient)
+}

--- a/crates/eip4844/src/prover.rs
+++ b/crates/eip4844/src/prover.rs
@@ -44,9 +44,7 @@ impl Context {
         let z = deserialize_bytes_to_scalar(&z)?;
 
         // Compute evaluation and quotient at challenge.
-        let (y, mut quotient) =
-            compute_evaluation_and_quotient(&self.prover.domain, &polynomial, z);
-        bitreverse_slice(&mut quotient);
+        let (y, quotient) = compute_evaluation_and_quotient(&self.prover.domain, &polynomial, z);
 
         // Compute KZG opening proof.
         let proof = g1_lincomb(&self.prover.commit_key.g1_lagrange, &quotient)
@@ -80,9 +78,8 @@ impl Context {
         let z = compute_fiat_shamir_challenge(blob, commitment);
 
         // Compute evaluation and quotient at z.
-        let (_, mut quotient) =
-            compute_evaluation_and_quotient(&self.prover.domain, &polynomial, z);
-        bitreverse_slice(&mut quotient);
+        // The quotient is returned in "normal order"
+        let (_, quotient) = compute_evaluation_and_quotient(&self.prover.domain, &polynomial, z);
 
         // Compute KZG opening proof.
         let proof = g1_lincomb(&self.prover.commit_key.g1_lagrange, &quotient)

--- a/crates/eip4844/src/prover.rs
+++ b/crates/eip4844/src/prover.rs
@@ -1,12 +1,13 @@
 use bls12_381::lincomb::g1_lincomb;
 
 use crate::{
-    cryptography::{bitreverse_slice, prover::compute_evaluation_and_quotient},
+    cryptography::{
+        bitreverse_slice, compute_fiat_shamir_challenge, prover::compute_evaluation_and_quotient,
+    },
     serialization::{
         deserialize_blob_to_scalars, deserialize_bytes_to_scalar, deserialize_compressed_g1,
         serialize_g1_compressed,
     },
-    verifier::compute_fiat_shamir_challenge,
     BlobRef, Context, Error, KZGCommitment, KZGOpeningEvaluation, KZGOpeningPoint, KZGProof,
 };
 

--- a/crates/eip4844/src/prover.rs
+++ b/crates/eip4844/src/prover.rs
@@ -4,45 +4,16 @@ use polynomial::domain::Domain;
 
 use crate::{
     constants::FIELD_ELEMENTS_PER_BLOB,
+    cryptography::{bitreverse, bitreverse_slice, prover::compute_evaluation_and_quotient},
     serialization::{
         deserialize_blob_to_scalars, deserialize_bytes_to_scalar, deserialize_compressed_g1,
         serialize_g1_compressed,
     },
     trusted_setup::{deserialize_g1_points, SubgroupCheck},
-    verifier::{bitreverse, bitreverse_slice, compute_fiat_shamir_challenge},
+    verifier::compute_fiat_shamir_challenge,
     BlobRef, Context, Error, KZGCommitment, KZGOpeningEvaluation, KZGOpeningPoint, KZGProof,
     TrustedSetup,
 };
-
-/// The key that is used to commit to polynomials in lagrange form (bit-reversed
-/// order)
-pub struct CommitKey {
-    g1_lagrange: Vec<G1Point>,
-}
-
-impl From<&TrustedSetup> for CommitKey {
-    fn from(setup: &TrustedSetup) -> Self {
-        let g1_lagrange = deserialize_g1_points(&setup.g1_lagrange, SubgroupCheck::NoCheck);
-        Self { g1_lagrange }
-    }
-}
-
-pub struct Prover {
-    /// Domain used to create the opening proofs.
-    domain: Domain,
-    /// Commitment key used for committing to the polynomial
-    /// in lagrange form
-    commit_key: CommitKey,
-}
-
-impl Prover {
-    pub fn new(trusted_setup: &TrustedSetup) -> Self {
-        Self {
-            domain: Domain::new(FIELD_ELEMENTS_PER_BLOB),
-            commit_key: CommitKey::from(trusted_setup),
-        }
-    }
-}
 
 impl Context {
     /// Computes the KZG commitment to the polynomial represented by the blob.
@@ -126,118 +97,4 @@ impl Context {
         // Serialize the commitment.
         Ok(serialize_g1_compressed(&proof))
     }
-}
-
-/// Compute evaluation and quotient of the given polynomial at the given point.
-fn compute_evaluation_and_quotient(
-    domain: &Domain,
-    polynomial: &[Scalar],
-    z: Scalar,
-) -> (Scalar, Vec<Scalar>) {
-    // Find the index of point if it's in the domain.
-    let point_idx = domain.roots.iter().position(|root| *root == z);
-
-    // Compute evaluation and quotient.
-    let (z, quotient) = point_idx.map_or_else(
-        || compute_evaluation_and_quotient_out_of_domain(domain, polynomial, z),
-        |point_idx| compute_evaluation_and_quotient_within_domain(domain, polynomial, point_idx),
-    );
-
-    (z, quotient)
-}
-
-/// Compute evaluation and quotient of the given polynomial at the given point.
-/// The point is guaranteed to be out-of-domain.
-fn compute_evaluation_and_quotient_out_of_domain(
-    domain: &Domain,
-    polynomial: &[Scalar],
-    z: Scalar,
-) -> (Scalar, Vec<Scalar>) {
-    let mut roots_brp = domain.roots.clone();
-    bitreverse_slice(&mut roots_brp);
-
-    // 1 / (z - ω^i)
-    let mut denoms = roots_brp.iter().map(|root| z - *root).collect::<Vec<_>>();
-    batch_inverse(&mut denoms);
-
-    // \sum (ω^i * f(ω^i) / (z - ω^i)) * ((z^n - 1) / n)
-    let y = roots_brp
-        .maybe_into_par_iter()
-        .zip(polynomial)
-        .zip(&denoms)
-        .map(|((root, f_root), denom)| root * *f_root * denom)
-        .sum::<Scalar>()
-        * (z.pow_vartime([FIELD_ELEMENTS_PER_BLOB as u64]) - Scalar::ONE)
-        * domain.domain_size_inv;
-
-    // (y - f(ω^i)) / (z - ω^i)
-    let quotient = denoms
-        .maybe_into_par_iter()
-        .zip(polynomial)
-        .map(|(denom, f_root)| (y - *f_root) * denom)
-        .collect();
-
-    (y, quotient)
-}
-
-/// Compute evaluation and quotient of the given polynomial at the given point
-/// index of the domain.
-///
-/// For more details, read [PCS multiproofs using random evaluation] section
-/// "Dividing when one of the points is zero".
-///
-/// The matching function in the specs is: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#compute_quotient_eval_within_domain
-///
-/// [PCS multiproofs using random evaluation]: https://dankradfeist.de/ethereum/2021/06/18/pcs-multiproofs.html
-fn compute_evaluation_and_quotient_within_domain(
-    domain: &Domain,
-    polynomial: &[Scalar],
-    point_idx: usize,
-) -> (Scalar, Vec<Scalar>) {
-    // ω^m
-    let z = domain.roots[point_idx];
-    // ω^(n-m)
-    let z_inv = domain.roots[(FIELD_ELEMENTS_PER_BLOB - point_idx) % FIELD_ELEMENTS_PER_BLOB];
-
-    // Because polynomial is in bit-reversed order, and we need to compute
-    // quotient also in bit-reversed order, so we work with bit-reversed point
-    // index from now on.
-    let point_idx_brp = bitreverse(point_idx as u32, FIELD_ELEMENTS_PER_BLOB.ilog2()) as usize;
-
-    // Root in bit-reversed order.
-    let mut roots_brp = domain.roots.clone();
-    bitreverse_slice(&mut roots_brp);
-
-    // f(ω^m)
-    let y = polynomial[point_idx_brp];
-
-    // 1 / (ω^m - ω^j)
-    // Note that we set (ω^m - ω^m) to be one to make the later `batch_inverse` work.
-    let mut denoms = (&roots_brp)
-        .maybe_into_par_iter()
-        .enumerate()
-        .map(|(idx, root)| {
-            (idx == point_idx_brp)
-                .then_some(Scalar::ONE)
-                .unwrap_or_else(|| z - root)
-        })
-        .collect::<Vec<_>>();
-    batch_inverse(&mut denoms);
-
-    // (f(ω^m) - f(ω^j)) / (ω^m - ω^j)
-    let mut quotient = denoms
-        .maybe_into_par_iter()
-        .zip(polynomial)
-        .map(|(denom, f_root)| (y - f_root) * denom)
-        .collect::<Vec<_>>();
-
-    // Compute q(ω^m) = \sum q(ω^j) * (A'(ω_m) / A'(ω_j)) = \sum q(ω^j) * (ω_j / ω_m)
-    quotient[point_idx_brp] = Scalar::ZERO;
-    quotient[point_idx_brp] = -roots_brp
-        .maybe_into_par_iter()
-        .zip(&quotient)
-        .map(|(root, quotient)| *quotient * root * z_inv)
-        .sum::<Scalar>();
-
-    (y, quotient)
 }

--- a/crates/eip4844/src/prover.rs
+++ b/crates/eip4844/src/prover.rs
@@ -19,6 +19,7 @@ impl Context {
         // Deserialize the blob into scalars.
         let mut polynomial = deserialize_blob_to_scalars(blob)?;
 
+        // Bit-reverse polynomial into normal order.
         bitreverse_slice(&mut polynomial);
 
         // Compute commitment in lagrange form.

--- a/crates/eip4844/src/prover.rs
+++ b/crates/eip4844/src/prover.rs
@@ -1,18 +1,13 @@
-use bls12_381::{batch_inversion::batch_inverse, ff::Field, lincomb::g1_lincomb, G1Point, Scalar};
-use maybe_rayon::prelude::*;
-use polynomial::domain::Domain;
+use bls12_381::lincomb::g1_lincomb;
 
 use crate::{
-    constants::FIELD_ELEMENTS_PER_BLOB,
-    cryptography::{bitreverse, bitreverse_slice, prover::compute_evaluation_and_quotient},
+    cryptography::{bitreverse_slice, prover::compute_evaluation_and_quotient},
     serialization::{
         deserialize_blob_to_scalars, deserialize_bytes_to_scalar, deserialize_compressed_g1,
         serialize_g1_compressed,
     },
-    trusted_setup::{deserialize_g1_points, SubgroupCheck},
     verifier::compute_fiat_shamir_challenge,
     BlobRef, Context, Error, KZGCommitment, KZGOpeningEvaluation, KZGOpeningPoint, KZGProof,
-    TrustedSetup,
 };
 
 impl Context {

--- a/crates/eip4844/src/serialization.rs
+++ b/crates/eip4844/src/serialization.rs
@@ -1,0 +1,68 @@
+use bls12_381::{G1Point, Scalar};
+
+use crate::constants::{BYTES_PER_BLOB, BYTES_PER_FIELD_ELEMENT, BYTES_PER_G1_POINT};
+pub use crate::errors::SerializationError;
+
+fn deserialize_bytes_to_scalars(bytes: &[u8]) -> Result<Vec<Scalar>, SerializationError> {
+    // Check that the bytes are a multiple of the scalar size
+    if bytes.len() % BYTES_PER_FIELD_ELEMENT != 0 {
+        return Err(SerializationError::ScalarHasInvalidLength {
+            length: bytes.len(),
+            bytes: bytes.to_vec(),
+        });
+    }
+
+    let bytes32s = bytes.chunks_exact(BYTES_PER_FIELD_ELEMENT);
+
+    let mut scalars = Vec::with_capacity(bytes32s.len());
+    for bytes32 in bytes32s {
+        scalars.push(deserialize_bytes_to_scalar(bytes32)?);
+    }
+    Ok(scalars)
+}
+
+pub(crate) fn deserialize_blob_to_scalars(
+    blob_bytes: &[u8],
+) -> Result<Vec<Scalar>, SerializationError> {
+    if blob_bytes.len() != BYTES_PER_BLOB {
+        return Err(SerializationError::BlobHasInvalidLength {
+            length: blob_bytes.len(),
+            bytes: blob_bytes.to_vec(),
+        });
+    }
+    deserialize_bytes_to_scalars(blob_bytes)
+}
+
+pub(crate) fn deserialize_bytes_to_scalar(
+    scalar_bytes: &[u8],
+) -> Result<Scalar, SerializationError> {
+    let bytes32 = scalar_bytes.try_into().expect("infallible: expected blob chunks to be exactly {SCALAR_SERIALIZED_SIZE} bytes, since blob was a multiple of {SCALAR_SERIALIZED_SIZE");
+
+    // Convert the CtOption into Option
+    let option_scalar: Option<Scalar> = Scalar::from_bytes_be(bytes32).into();
+    option_scalar.map_or_else(
+        || {
+            Err(SerializationError::CouldNotDeserializeScalar {
+                bytes: scalar_bytes.to_vec(),
+            })
+        },
+        Ok,
+    )
+}
+
+pub(crate) fn deserialize_compressed_g1(point_bytes: &[u8]) -> Result<G1Point, SerializationError> {
+    let Ok(point_bytes) = point_bytes.try_into() else {
+        return Err(SerializationError::G1PointHasInvalidLength {
+            length: point_bytes.len(),
+            bytes: point_bytes.to_vec(),
+        });
+    };
+
+    let opt_g1: Option<G1Point> = Option::from(G1Point::from_compressed(point_bytes));
+    opt_g1.ok_or_else(|| SerializationError::CouldNotDeserializeG1Point {
+        bytes: point_bytes.to_vec(),
+    })
+}
+pub(crate) fn serialize_g1_compressed(point: &G1Point) -> [u8; BYTES_PER_G1_POINT] {
+    point.to_compressed()
+}

--- a/crates/eip4844/src/trusted_setup.rs
+++ b/crates/eip4844/src/trusted_setup.rs
@@ -1,0 +1,149 @@
+use bls12_381::{G1Point, G2Point};
+use serde::Deserialize;
+
+const TRUSTED_SETUP_JSON: &str = include_str!("../../eip7594/data/trusted_setup_4096.json");
+
+#[derive(Deserialize, Debug, PartialEq, Eq)]
+pub struct TrustedSetup {
+    /// G1 Monomial represents a list of uncompressed
+    /// hex encoded group elements in the G1 group on the bls12-381 curve.
+    ///
+    /// Ethereum has multiple trusted setups, however the one being
+    /// used currently contains 4096 G1 elements.
+    pub g1_monomial: Vec<String>,
+    /// G1 Lagrange represents a list of uncompressed
+    /// hex encoded group elements in the G1 group on the bls12-381 curve.
+    ///
+    /// These are related to `G1 Monomial` in that they are what one
+    /// would get if we did an inverse FFT on the `G1 monomial` elements.
+    ///
+    /// The length of this vector is equal to the length of G1_Monomial.
+    pub g1_lagrange: Vec<String>,
+    /// G2 Monomial represents a list of uncompressed hex encoded
+    /// group elements in the G2 group on the bls12-381 curve.
+    ///
+    /// The length of this vector is 65.
+    pub g2_monomial: Vec<String>,
+}
+
+impl Default for TrustedSetup {
+    fn default() -> Self {
+        Self::from_embed()
+    }
+}
+
+/// An enum used to specify whether to check that the points are in the correct subgroup
+#[derive(Debug, Copy, Clone)]
+pub(crate) enum SubgroupCheck {
+    #[allow(dead_code)]
+    Check,
+    NoCheck,
+}
+
+impl TrustedSetup {
+    /// Parse a Json string in the format specified by the ethereum trusted setup.
+    ///
+    /// The file that is being used on mainnet is located here: https://github.com/ethereum/consensus-specs/blob/389b2ddfb954731da7ccf4c0ef89fab2d4575b99/presets/mainnet/trusted_setups/trusted_setup_4096.json
+    ///
+    // The format that the file follows that this function also accepts, looks like the following:
+    /*
+    {
+      "g1_monomial": [
+        "0x97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb",
+        ...
+      ],
+      "g1_lagrange": [
+        "0xa0413c0dcafec6dbc9f47d66785cf1e8c981044f7d13cfe3e4fcbb71b5408dfde6312493cb3c1d30516cb3ca88c03654",
+        "0x8b997fb25730d661918371bb41f2a6e899cac23f04fc5365800b75433c0a953250e15e7a98fb5ca5cc56a8cd34c20c57",
+        ...
+      ],
+      "g2_monomial": [
+        "0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8",
+        ...
+      ]
+    }
+    */
+    pub fn from_json(json: &str) -> Self {
+        let trusted_setup = Self::from_json_unchecked(json);
+        // trusted_setup.validate_trusted_setup();
+        trusted_setup
+    }
+    /// Parse a Json string in the format specified by the ethereum trusted setup.
+    ///
+    /// This method does not check that the points are in the correct subgroup.
+    pub fn from_json_unchecked(json: &str) -> Self {
+        // Note: it is fine to panic here since this method is called on startup
+        // and we want to fail fast if the trusted setup is malformed.
+        serde_json::from_str(json)
+            .expect("could not parse json string into a TrustedSetup structure")
+    }
+
+    /// Loads the official trusted setup file being used on mainnet from the embedded data folder.
+    fn from_embed() -> Self {
+        Self::from_json_unchecked(TRUSTED_SETUP_JSON)
+    }
+}
+
+/// Deserialize G1 points from hex strings without checking that the element
+/// is in the correct subgroup.
+pub(crate) fn deserialize_g1_points<T: AsRef<str>>(
+    g1_points_hex_str: &[T],
+    check: SubgroupCheck,
+) -> Vec<G1Point> {
+    let mut g1_points = Vec::new();
+    for g1_hex_str in g1_points_hex_str {
+        let g1_hex_str = g1_hex_str.as_ref();
+
+        let g1_hex_str_without_0x = g1_hex_str
+            .strip_prefix("0x")
+            .expect("expected hex points to be prefixed with `0x`");
+        let g1_point_bytes: [u8; 48] = hex::decode(g1_hex_str_without_0x)
+            .expect("trusted setup has malformed g1 points")
+            .try_into()
+            .expect("expected 48 bytes for G1 point");
+
+        let point = match check {
+            SubgroupCheck::Check => {
+                G1Point::from_compressed(&g1_point_bytes).expect("invalid g1 point")
+            }
+            SubgroupCheck::NoCheck => {
+                G1Point::from_compressed_unchecked(&g1_point_bytes).expect("invalid g1 point")
+            }
+        };
+
+        g1_points.push(point);
+    }
+
+    g1_points
+}
+
+/// Deserialize G2 points from hex strings without checking that the element
+/// is in the correct subgroup.
+pub(crate) fn deserialize_g2_points<T: AsRef<str>>(
+    g2_points_hex_str: &[T],
+    subgroup_check: SubgroupCheck,
+) -> Vec<G2Point> {
+    let mut g2_points = Vec::new();
+    for g2_hex_str in g2_points_hex_str {
+        let g2_hex_str = g2_hex_str.as_ref();
+        let g2_hex_str_without_0x = g2_hex_str
+            .strip_prefix("0x")
+            .expect("expected hex points to be prefixed with `0x`");
+        let g2_point_bytes: [u8; 96] = hex::decode(g2_hex_str_without_0x)
+            .expect("trusted setup has malformed g2 points")
+            .try_into()
+            .expect("expected 96 bytes for G2 point");
+
+        let point = match subgroup_check {
+            SubgroupCheck::Check => {
+                G2Point::from_compressed(&g2_point_bytes).expect("invalid g2 point")
+            }
+            SubgroupCheck::NoCheck => {
+                G2Point::from_compressed_unchecked(&g2_point_bytes).expect("invalid g2 point")
+            }
+        };
+        g2_points.push(point);
+    }
+
+    g2_points
+}

--- a/crates/eip4844/src/trusted_setup.rs
+++ b/crates/eip4844/src/trusted_setup.rs
@@ -1,7 +1,31 @@
 use bls12_381::{G1Point, G2Point};
 use serde::Deserialize;
 
+use crate::cryptography::{prover::CommitKey, verifier::VerificationKey};
+
 const TRUSTED_SETUP_JSON: &str = include_str!("../../eip7594/data/trusted_setup_4096.json");
+
+impl From<&TrustedSetup> for VerificationKey {
+    fn from(setup: &TrustedSetup) -> Self {
+        let g1_monomial = deserialize_g1_points(&setup.g1_monomial, SubgroupCheck::NoCheck);
+        let g2_monomial = deserialize_g2_points(&setup.g2_monomial, SubgroupCheck::NoCheck);
+        let gen_g1 = g1_monomial[0];
+        let gen_g2 = g2_monomial[0];
+        let tau_g2 = g2_monomial[1];
+        Self {
+            gen_g1,
+            gen_g2,
+            tau_g2,
+        }
+    }
+}
+
+impl From<&TrustedSetup> for CommitKey {
+    fn from(setup: &TrustedSetup) -> Self {
+        let g1_lagrange = deserialize_g1_points(&setup.g1_lagrange, SubgroupCheck::NoCheck);
+        Self { g1_lagrange }
+    }
+}
 
 #[derive(Deserialize, Debug, PartialEq, Eq)]
 pub struct TrustedSetup {

--- a/crates/eip4844/src/verifier.rs
+++ b/crates/eip4844/src/verifier.rs
@@ -1,0 +1,444 @@
+use std::iter::successors;
+
+use bls12_381::{
+    batch_inversion::batch_inverse, ff::Field, group::Curve, lincomb::g1_lincomb, multi_pairings,
+    reduce_bytes_to_scalar_bias, G1Point, G2Point, G2Prepared, Scalar,
+};
+use polynomial::domain::Domain;
+use sha2::{Digest, Sha256};
+
+use crate::{
+    constants::{
+        BYTES_PER_BLOB, BYTES_PER_COMMITMENT, BYTES_PER_FIELD_ELEMENT, FIELD_ELEMENTS_PER_BLOB,
+    },
+    serialization::{
+        deserialize_blob_to_scalars, deserialize_bytes_to_scalar, deserialize_compressed_g1,
+    },
+    trusted_setup::{deserialize_g1_points, deserialize_g2_points, SubgroupCheck, TrustedSetup},
+    BlobRef, Context, Error, KZGCommitment, KZGOpeningEvaluation, KZGOpeningPoint, KZGProof,
+    VerifierError,
+};
+
+/// The key that is used to verify KZG single-point opening proofs.
+pub struct VerificationKey {
+    gen_g1: G1Point,
+    gen_g2: G2Point,
+    tau_g2: G2Point,
+}
+
+impl From<&TrustedSetup> for VerificationKey {
+    fn from(setup: &TrustedSetup) -> Self {
+        let g1_monomial = deserialize_g1_points(&setup.g1_monomial, SubgroupCheck::NoCheck);
+        let g2_monomial = deserialize_g2_points(&setup.g2_monomial, SubgroupCheck::NoCheck);
+        let gen_g1 = g1_monomial[0];
+        let gen_g2 = g2_monomial[0];
+        let tau_g2 = g2_monomial[1];
+        Self {
+            gen_g1,
+            gen_g2,
+            tau_g2,
+        }
+    }
+}
+
+pub struct Verifier {
+    /// Domain used to create the opening proofs.
+    domain: Domain,
+    /// Verification key used to verify KZG single-point opening proofs.
+    verification_key: VerificationKey,
+}
+
+impl Verifier {
+    pub fn new(trusted_setup: &TrustedSetup) -> Self {
+        Self {
+            domain: Domain::new(FIELD_ELEMENTS_PER_BLOB),
+            verification_key: VerificationKey::from(trusted_setup),
+        }
+    }
+
+    fn verify_kzg_proof(
+        &self,
+        commitment: G1Point,
+        z: Scalar,
+        y: Scalar,
+        proof: G1Point,
+    ) -> Result<(), VerifierError> {
+        let vk = &self.verification_key;
+
+        // [f(τ) - f(z)]G₁
+        let commitment_minus_z = (commitment - vk.gen_g1 * y).into();
+
+        // [-1]G₂
+        let neg_gen_g2 = G2Prepared::from(-vk.gen_g2);
+
+        // [τ - z]G₂
+        let tau_minus_challenge_g2 = G2Prepared::from((vk.tau_g2 - vk.gen_g2 * z).to_affine());
+
+        // Check whether `f(X) - f(z) == q(X) * (X - z)`
+        let proof_valid = multi_pairings(&[
+            (&commitment_minus_z, &neg_gen_g2),
+            (&proof, &tau_minus_challenge_g2),
+        ]);
+        if proof_valid {
+            Ok(())
+        } else {
+            Err(VerifierError::InvalidProof)
+        }
+    }
+
+    fn verify_kzg_proof_batch(
+        &self,
+        commitments: &[G1Point],
+        zs: &[Scalar],
+        ys: &[Scalar],
+        proofs: &[G1Point],
+        r_powers: &[Scalar],
+    ) -> Result<(), VerifierError> {
+        assert!(
+            commitments.len() == zs.len()
+                && commitments.len() == ys.len()
+                && commitments.len() == proofs.len()
+                && commitments.len() == r_powers.len()
+        );
+
+        let vk = &self.verification_key;
+
+        // \sum r^i * [f_i(τ)] - (\sum r^i * y_i) * [1] + \sum r^i * z_i * [q(τ)]
+        let lhs_g1 = {
+            let points = commitments
+                .iter()
+                .chain(proofs)
+                .chain([&vk.gen_g1])
+                .copied()
+                .collect::<Vec<_>>();
+            let scalars = r_powers
+                .iter()
+                .copied()
+                .chain(r_powers.iter().zip(zs).map(|(r_i, z_i)| *r_i * z_i))
+                .chain([-r_powers
+                    .iter()
+                    .zip(ys)
+                    .map(|(r_i, y_i)| *r_i * y_i)
+                    .sum::<Scalar>()])
+                .collect::<Vec<_>>();
+            g1_lincomb(&points, &scalars)
+                .expect("points and scalars have same length")
+                .into()
+        };
+
+        // \sum r^i * [q(τ)]
+        let rhs_g1 = g1_lincomb(proofs, r_powers)
+            .expect("points and scalars have same length")
+            .into();
+
+        // [-1]G₂
+        let lhs_g2 = G2Prepared::from(-vk.gen_g2);
+
+        // [τ]G₂
+        let rhs_g2 = G2Prepared::from(vk.tau_g2);
+
+        let proof_valid = multi_pairings(&[(&lhs_g1, &lhs_g2), (&rhs_g1, &rhs_g2)]);
+        if proof_valid {
+            Ok(())
+        } else {
+            Err(VerifierError::InvalidProof)
+        }
+    }
+}
+
+impl Context {
+    /// Verify the KZG proof to the commitment.
+    ///
+    /// The matching function in the specs is: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#verify_kzg_proof
+    pub fn verify_kzg_proof(
+        &self,
+        commitment: KZGCommitment,
+        z: KZGOpeningPoint,
+        y: KZGOpeningEvaluation,
+        proof: KZGProof,
+    ) -> Result<(), Error> {
+        // Deserialize the KZG commitment.
+        let commitment = deserialize_compressed_g1(&commitment)?;
+
+        // Deserialize the KZG proof.
+        let proof = deserialize_compressed_g1(&proof)?;
+
+        // Deserialize the point into scalar.
+        let z = deserialize_bytes_to_scalar(&z)?;
+
+        // Deserialize the evaluation into scalar.
+        let y = deserialize_bytes_to_scalar(&y)?;
+
+        // Verify KZG proof.
+        self.verifier.verify_kzg_proof(commitment, z, y, proof)?;
+
+        Ok(())
+    }
+
+    /// Verify the KZG proof to the commitment of a blob.
+    ///
+    /// The matching function in the specs is: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#verify_blob_kzg_proof
+    pub fn verify_blob_kzg_proof(
+        &self,
+        blob: BlobRef,
+        commitment: KZGCommitment,
+        proof: KZGProof,
+    ) -> Result<(), Error> {
+        // Deserialize the blob into scalars.
+        let polynomial = deserialize_blob_to_scalars(blob)?;
+
+        // Deserialize the KZG commitment.
+        let commitment_g1 = deserialize_compressed_g1(&commitment)?;
+
+        // Deserialize the KZG proof.
+        let proof = deserialize_compressed_g1(&proof)?;
+
+        // Compute Fiat-Shamir challenge
+        let z = compute_fiat_shamir_challenge(blob, commitment);
+
+        // Compute evaluation at z.
+        let y = compute_evaluation(&self.verifier.domain, &polynomial, z);
+
+        // Verify KZG proof.
+        self.verifier.verify_kzg_proof(commitment_g1, z, y, proof)?;
+
+        Ok(())
+    }
+
+    /// Verify a batch of KZG proof to a the commitment of a blob.
+    ///
+    /// The matching function in the specs is: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#verify_blob_kzg_proof_batch
+    pub fn verify_blob_kzg_proof_batch(
+        &self,
+        blobs: &[BlobRef],
+        commitments: &[KZGCommitment],
+        proofs: &[KZGProof],
+    ) -> Result<(), Error> {
+        let same_length = (blobs.len() == commitments.len()) & (blobs.len() == proofs.len());
+        if !same_length {
+            return Err(VerifierError::BatchVerificationInputsMustHaveSameLength {
+                blobs_len: blobs.len(),
+                commitments_len: commitments.len(),
+                proofs_len: proofs.len(),
+            }
+            .into());
+        }
+
+        // Deserialize the blobs into scalars.
+        let polynomials = blobs
+            .iter()
+            .map(|blob| deserialize_blob_to_scalars(*blob))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // Deserialize the KZG commitments.
+        let commitments_g1 = commitments
+            .iter()
+            .map(|commitment| deserialize_compressed_g1(commitment))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // Deserialize the KZG proofs.
+        let proofs_g1 = proofs
+            .iter()
+            .map(|proof| deserialize_compressed_g1(proof))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // Compute each Fiat-Shamir challenge and evaluation for each proof.
+        let (zs, ys) = blobs
+            .iter()
+            .zip(&polynomials)
+            .zip(commitments)
+            .map(|((blob, polynomial), commitment)| {
+                // Compute Fiat-Shamir challenge
+                let z = compute_fiat_shamir_challenge(blob, *commitment);
+
+                // Compute evaluation at z.
+                let y = compute_evaluation(&self.verifier.domain, polynomial, z);
+
+                (z, y)
+            })
+            .unzip::<_, _, Vec<_>, Vec<_>>();
+
+        // Compute powers Fiat-Shamir challenge for KZG batch verification.
+        let r_powers = compute_r_powers_for_verify_kzg_proof_batch(commitments, &zs, &ys, proofs);
+
+        // Verify KZG proof in batch.
+        self.verifier
+            .verify_kzg_proof_batch(&commitments_g1, &zs, &ys, &proofs_g1, &r_powers)?;
+
+        Ok(())
+    }
+}
+
+/// Compute Fiat-Shamir challenge of a blob KZG proof.
+///
+/// The matching function in the specs is: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#compute_challenge
+pub(crate) fn compute_fiat_shamir_challenge(blob: BlobRef, commitment: KZGCommitment) -> Scalar {
+    // DomSepProtocol is a Domain Separator to identify the protocol.
+    //
+    // It matches [FIAT_SHAMIR_PROTOCOL_DOMAIN] in the spec.
+    //
+    // [FIAT_SHAMIR_PROTOCOL_DOMAIN]: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#blob
+    const DOMAIN_SEP: &str = "FSBLOBVERIFY_V1_";
+
+    let hash_input_size = DOMAIN_SEP.len()
+            + 2 * size_of::<u64>() // polynomial bound
+            + BYTES_PER_BLOB // blob
+            + BYTES_PER_COMMITMENT // commitment
+            ;
+
+    let mut hash_input: Vec<u8> = Vec::with_capacity(hash_input_size);
+
+    hash_input.extend(DOMAIN_SEP.as_bytes());
+    hash_input.extend(u64_to_byte_array_16(FIELD_ELEMENTS_PER_BLOB as u64));
+    hash_input.extend(blob);
+    hash_input.extend(commitment);
+
+    assert_eq!(hash_input.len(), hash_input_size);
+    let mut hasher = Sha256::new();
+    hasher.update(hash_input);
+    let result: [u8; 32] = hasher.finalize().into();
+
+    // For randomization, we only need a 128 bit scalar, since this is used for batch verification.
+    // See for example, the randomizers section in : https://cr.yp.to/badbatch/badbatch-20120919.pdf
+    //
+    // This is noted because when we convert a 256 bit hash to a scalar, a bias will be introduced.
+    // This however does not affect our security guarantees because the bias is negligible given we
+    // want a uniformly random 128 bit integer.
+    //
+    // Also there is a negligible probably that the scalar is zero, so we do not handle this case here.
+    reduce_bytes_to_scalar_bias(result)
+}
+
+/// Compute random linear combination challenge scalars for batch verification.
+///
+/// The matching function in the specs is: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#verify_kzg_proof_batch
+fn compute_r_powers_for_verify_kzg_proof_batch(
+    commitments: &[KZGCommitment],
+    zs: &[Scalar],
+    ys: &[Scalar],
+    proofs: &[KZGProof],
+) -> Vec<Scalar> {
+    // DomSepProtocol is a Domain Separator to identify the protocol.
+    //
+    // It matches [RANDOM_CHALLENGE_KZG_BATCH_DOMAIN] in the spec.
+    //
+    // [RANDOM_CHALLENGE_KZG_BATCH_DOMAIN]: https://github.com/ethereum/consensus-specs/blob/017a8495f7671f5fff2075a9bfc9238c1a0982f8/specs/deneb/polynomial-commitments.md#blob
+    const DOMAIN_SEP: &str = "RCKZGBATCH___V1_";
+
+    let n = commitments.len();
+
+    let hash_input_size = DOMAIN_SEP.len()
+        + size_of::<u64>() // polynomial bound
+        + size_of::<u64>() // batch size
+        + n * (
+            BYTES_PER_COMMITMENT // commitment
+            + BYTES_PER_FIELD_ELEMENT // z 
+            + BYTES_PER_FIELD_ELEMENT // y
+            + BYTES_PER_COMMITMENT // proof
+        );
+
+    let mut hash_input: Vec<u8> = Vec::with_capacity(hash_input_size);
+
+    hash_input.extend(DOMAIN_SEP.as_bytes());
+    hash_input.extend((FIELD_ELEMENTS_PER_BLOB as u64).to_be_bytes());
+    hash_input.extend((n as u64).to_be_bytes());
+    commitments
+        .iter()
+        .zip(zs)
+        .zip(ys)
+        .zip(proofs)
+        .for_each(|(((commitment, z), y), proof)| {
+            hash_input.extend(commitment);
+            hash_input.extend(z.to_bytes_be());
+            hash_input.extend(y.to_bytes_be());
+            hash_input.extend(proof);
+        });
+
+    assert_eq!(hash_input.len(), hash_input_size);
+    let mut hasher = Sha256::new();
+    hasher.update(hash_input);
+    let result: [u8; 32] = hasher.finalize().into();
+
+    // For randomization, we only need a 128 bit scalar, since this is used for batch verification.
+    // See for example, the randomizers section in : https://cr.yp.to/badbatch/badbatch-20120919.pdf
+    //
+    // This is noted because when we convert a 256 bit hash to a scalar, a bias will be introduced.
+    // This however does not affect our security guarantees because the bias is negligible given we
+    // want a uniformly random 128 bit integer.
+    //
+    // Also there is a negligible probably that the scalar is zero, so we do not handle this case here.
+    let r = reduce_bytes_to_scalar_bias(result);
+
+    successors(Some(Scalar::ONE), |power| Some(*power * r))
+        .take(n)
+        .collect()
+}
+
+/// Converts a u64 to a byte array of length 16 in big endian format.
+/// This implies that the first 8 bytes of the result are always 0.
+fn u64_to_byte_array_16(number: u64) -> [u8; 16] {
+    let mut bytes = [0; 16];
+    bytes[8..].copy_from_slice(&number.to_be_bytes());
+    bytes
+}
+
+/// Compute evaluation of the given polynomial at the given point.
+pub(crate) fn compute_evaluation(domain: &Domain, polynomial: &[Scalar], z: Scalar) -> Scalar {
+    domain.roots.iter().position(|root| *root == z).map_or_else(
+        || compute_evaluation_out_of_domain(domain, polynomial, z),
+        |position| polynomial[position],
+    )
+}
+
+/// Compute evaluation of the given polynomial at the given point.
+/// The point is guaranteed to be out-of-domain.
+pub(crate) fn compute_evaluation_out_of_domain(
+    domain: &Domain,
+    polynomial: &[Scalar],
+    z: Scalar,
+) -> Scalar {
+    let mut roots_brp = domain.roots.clone();
+    bitreverse_slice(&mut roots_brp);
+
+    // 1 / (z - ω^i)
+    let mut denoms = roots_brp.iter().map(|root| z - *root).collect::<Vec<_>>();
+    batch_inverse(&mut denoms);
+
+    // \sum (ω^i * f(ω^i) / (z - ω^i)) * ((z^n - 1) / n)
+    let y = roots_brp
+        .iter()
+        .zip(polynomial)
+        .zip(&denoms)
+        .map(|((root, f_root), denom)| root * *f_root * denom)
+        .sum::<Scalar>()
+        * (z.pow_vartime([FIELD_ELEMENTS_PER_BLOB as u64]) - Scalar::ONE)
+        * domain.domain_size_inv;
+
+    y
+}
+
+pub(crate) fn bitreverse(mut n: u32, l: u32) -> u32 {
+    let mut r = 0;
+    for _ in 0..l {
+        r = (r << 1) | (n & 1);
+        n >>= 1;
+    }
+    r
+}
+
+pub(crate) fn bitreverse_slice<T>(a: &mut [T]) {
+    if a.is_empty() {
+        return;
+    }
+
+    let n = a.len();
+    let log_n = n.ilog2();
+    assert_eq!(n, 1 << log_n);
+
+    for k in 0..n {
+        let rk = bitreverse(k as u32, log_n) as usize;
+        if k < rk {
+            a.swap(rk, k);
+        }
+    }
+}

--- a/crates/eip4844/src/verifier.rs
+++ b/crates/eip4844/src/verifier.rs
@@ -397,6 +397,7 @@ pub(crate) fn compute_evaluation_out_of_domain(
     polynomial: &[Scalar],
     z: Scalar,
 ) -> Scalar {
+    // Note: This clone is okay because after eip7594, this crate is no longer on the critical path.
     let mut roots_brp = domain.roots.clone();
     bitreverse_slice(&mut roots_brp);
 

--- a/crates/eip4844/src/verifier.rs
+++ b/crates/eip4844/src/verifier.rs
@@ -267,6 +267,8 @@ pub(crate) fn compute_evaluation_out_of_domain(
     polynomial: &[Scalar],
     z: Scalar,
 ) -> Scalar {
+    let domain_size = domain.roots.len();
+
     // Note: This clone is okay because after eip7594, this crate is no longer on the critical path.
     let mut roots_brp = domain.roots.clone();
     bitreverse_slice(&mut roots_brp);
@@ -282,7 +284,7 @@ pub(crate) fn compute_evaluation_out_of_domain(
         .zip(&denoms)
         .map(|((root, f_root), denom)| root * *f_root * denom)
         .sum::<Scalar>()
-        * (z.pow_vartime([FIELD_ELEMENTS_PER_BLOB as u64]) - Scalar::ONE)
+        * (z.pow_vartime([domain_size as u64]) - Scalar::ONE)
         * domain.domain_size_inv;
 
     y

--- a/crates/eip4844/tests/blob_to_kzg_commitment.rs
+++ b/crates/eip4844/tests/blob_to_kzg_commitment.rs
@@ -1,0 +1,91 @@
+use std::fs;
+
+use common::collect_test_files;
+use serde_::TestVector;
+use tbd::constants::BYTES_PER_BLOB;
+
+#[path = "../../eip7594/tests/common.rs"]
+mod common;
+
+mod serde_ {
+
+    use serde::Deserialize;
+
+    use super::common::{bytes_from_hex, UnsafeBytes};
+
+    #[derive(Deserialize)]
+    struct YamlInput {
+        blob: String,
+    }
+
+    type YamlOutput = String;
+
+    #[derive(Deserialize)]
+    struct YamlTestVector {
+        input: YamlInput,
+        output: Option<YamlOutput>,
+    }
+
+    pub struct TestVector {
+        pub blob: UnsafeBytes,
+        pub commitment: Option<UnsafeBytes>,
+    }
+
+    impl TestVector {
+        pub fn from_str(yaml_data: &str) -> Self {
+            let yaml_test_vector: YamlTestVector =
+                serde_yaml::from_str(yaml_data).expect("invalid yaml");
+            Self::from(yaml_test_vector)
+        }
+    }
+
+    impl From<YamlTestVector> for TestVector {
+        fn from(yaml_test_vector: YamlTestVector) -> Self {
+            let input = yaml_test_vector.input.blob;
+            let output = yaml_test_vector.output;
+
+            let input = bytes_from_hex(&input);
+
+            let commitment = output.map(|commitment| bytes_from_hex(&commitment));
+
+            Self {
+                blob: input,
+                commitment,
+            }
+        }
+    }
+}
+
+const TEST_DIR: &str = "../../test_vectors/blob_to_kzg_commitment";
+#[test]
+fn test_blob_to_kzg_commitment() {
+    let test_files = collect_test_files(TEST_DIR).expect("unable to collect test files");
+
+    let ctx = tbd::Context::default();
+
+    for test_file in test_files {
+        let yaml_data = fs::read_to_string(test_file).expect("unable to read test file");
+        let test = TestVector::from_str(&yaml_data);
+
+        //
+        let blob: &[u8; BYTES_PER_BLOB] = if let Ok(blob) = (&test.blob[..]).try_into() {
+            blob
+        } else {
+            // Blob does not have a valid size
+            assert!(test.commitment.is_none());
+            continue;
+        };
+
+        match ctx.blob_to_kzg_commitment(blob) {
+            Ok(commitment) => {
+                let expected_commitment = test.commitment.expect("commitment is none");
+
+                assert_eq!(&commitment[..], &expected_commitment);
+            }
+            Err(_) => {
+                // On an error, we expect the output to be null
+                assert!(test.commitment.is_none());
+            }
+        }
+    }
+}

--- a/crates/eip4844/tests/blob_to_kzg_commitment.rs
+++ b/crates/eip4844/tests/blob_to_kzg_commitment.rs
@@ -1,10 +1,9 @@
 use std::fs;
 
 use common::collect_test_files;
+use eip4844::constants::BYTES_PER_BLOB;
 use serde_::TestVector;
-use tbd::constants::BYTES_PER_BLOB;
 
-#[path = "../../eip7594/tests/common.rs"]
 mod common;
 
 mod serde_ {
@@ -61,7 +60,7 @@ const TEST_DIR: &str = "../../test_vectors/blob_to_kzg_commitment";
 fn test_blob_to_kzg_commitment() {
     let test_files = collect_test_files(TEST_DIR).expect("unable to collect test files");
 
-    let ctx = tbd::Context::default();
+    let ctx = eip4844::Context::default();
 
     for test_file in test_files {
         let yaml_data = fs::read_to_string(test_file).expect("unable to read test file");

--- a/crates/eip4844/tests/common.rs
+++ b/crates/eip4844/tests/common.rs
@@ -1,0 +1,51 @@
+/// Data from the test input could also be malformed,
+/// So we use this type to represent that.
+/// For example, although a proof should be 48 bytes, the test input
+/// could give us 47.
+pub type UnsafeBytes = Vec<u8>;
+
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+pub fn collect_test_files<P: AsRef<Path>>(dir: P) -> io::Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    collect_test_files_inner(dir, &mut files)?;
+
+    // Check that the directory is not empty
+    assert!(!files.is_empty());
+
+    Ok(files)
+}
+
+fn collect_test_files_inner<P: AsRef<Path>>(dir: P, files: &mut Vec<PathBuf>) -> io::Result<()> {
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_test_files_inner(path, files)?;
+        } else if path.is_file() {
+            files.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn remove_hex_prefix(s: &str) -> &str {
+    s.strip_prefix("0x").map_or_else(
+        || {
+            panic!(
+                "hex strings in ethereum are assumed to be prefixed with a 0x.
+                If this is not the case, it is not a bug, however it is cause for concern,
+                if there are discrepancies."
+            );
+        },
+        |stripped| stripped,
+    )
+}
+
+pub fn bytes_from_hex(bytes: &str) -> Vec<u8> {
+    let bytes = remove_hex_prefix(bytes);
+    hex::decode(bytes).unwrap()
+}

--- a/crates/eip4844/tests/compute_blob_kzg_proof.rs
+++ b/crates/eip4844/tests/compute_blob_kzg_proof.rs
@@ -1,0 +1,104 @@
+use std::fs;
+
+use common::collect_test_files;
+use serde_::TestVector;
+use tbd::constants::{BYTES_PER_BLOB, BYTES_PER_COMMITMENT};
+
+#[path = "../../eip7594/tests/common.rs"]
+mod common;
+
+mod serde_ {
+
+    use serde::Deserialize;
+
+    use super::common::{bytes_from_hex, UnsafeBytes};
+
+    #[derive(Deserialize)]
+    struct YamlInput {
+        blob: String,
+        commitment: String,
+    }
+
+    type YamlOutput = String;
+
+    #[derive(Deserialize)]
+    struct YamlTestVector {
+        input: YamlInput,
+        output: Option<YamlOutput>,
+    }
+
+    pub struct TestVector {
+        pub blob: UnsafeBytes,
+        pub commitment: UnsafeBytes,
+        pub output: Option<UnsafeBytes>,
+    }
+
+    impl TestVector {
+        pub fn from_str(yaml_data: &str) -> Self {
+            let yaml_test_vector: YamlTestVector =
+                serde_yaml::from_str(yaml_data).expect("invalid yaml");
+            Self::from(yaml_test_vector)
+        }
+    }
+
+    impl From<YamlTestVector> for TestVector {
+        fn from(yaml_test_vector: YamlTestVector) -> Self {
+            let blob = yaml_test_vector.input.blob;
+            let commitment = yaml_test_vector.input.commitment;
+            let output = yaml_test_vector.output;
+
+            let blob = bytes_from_hex(&blob);
+            let commitment = bytes_from_hex(&commitment);
+
+            let output = output.map(|output| bytes_from_hex(&output));
+
+            Self {
+                blob,
+                commitment,
+                output,
+            }
+        }
+    }
+}
+
+const TEST_DIR: &str = "../../test_vectors/compute_blob_kzg_proof";
+#[test]
+fn test_compute_blob_kzg_proof() {
+    let test_files = collect_test_files(TEST_DIR).expect("unable to collect test files");
+
+    let ctx = tbd::Context::default();
+
+    for test_file in test_files {
+        let yaml_data = fs::read_to_string(test_file).expect("unable to read test file");
+        let test = TestVector::from_str(&yaml_data);
+
+        let blob: &[u8; BYTES_PER_BLOB] = if let Ok(blob) = (&test.blob[..]).try_into() {
+            blob
+        } else {
+            // Blob does not have a valid size
+            assert!(test.output.is_none());
+            continue;
+        };
+
+        let commitment: [u8; BYTES_PER_COMMITMENT] =
+            if let Ok(commitment) = test.commitment.try_into() {
+                commitment
+            } else {
+                // z does not have a valid size
+                assert!(test.output.is_none());
+                continue;
+            };
+
+        match ctx.compute_blob_kzg_proof(blob, commitment) {
+            Ok(proof) => {
+                let expected_proof = test.output.expect("output is none");
+
+                assert_eq!(&proof[..], &expected_proof);
+            }
+            Err(_) => {
+                // On an error, we expect the output to be null
+                assert!(test.output.is_none());
+            }
+        }
+    }
+}

--- a/crates/eip4844/tests/compute_blob_kzg_proof.rs
+++ b/crates/eip4844/tests/compute_blob_kzg_proof.rs
@@ -1,10 +1,9 @@
 use std::fs;
 
 use common::collect_test_files;
+use eip4844::constants::{BYTES_PER_BLOB, BYTES_PER_COMMITMENT};
 use serde_::TestVector;
-use tbd::constants::{BYTES_PER_BLOB, BYTES_PER_COMMITMENT};
 
-#[path = "../../eip7594/tests/common.rs"]
 mod common;
 
 mod serde_ {
@@ -66,7 +65,7 @@ const TEST_DIR: &str = "../../test_vectors/compute_blob_kzg_proof";
 fn test_compute_blob_kzg_proof() {
     let test_files = collect_test_files(TEST_DIR).expect("unable to collect test files");
 
-    let ctx = tbd::Context::default();
+    let ctx = eip4844::Context::default();
 
     for test_file in test_files {
         let yaml_data = fs::read_to_string(test_file).expect("unable to read test file");

--- a/crates/eip4844/tests/compute_kzg_proof.rs
+++ b/crates/eip4844/tests/compute_kzg_proof.rs
@@ -1,10 +1,9 @@
 use std::fs;
 
 use common::collect_test_files;
+use eip4844::constants::{BYTES_PER_BLOB, BYTES_PER_FIELD_ELEMENT};
 use serde_::TestVector;
-use tbd::constants::{BYTES_PER_BLOB, BYTES_PER_FIELD_ELEMENT};
 
-#[path = "../../eip7594/tests/common.rs"]
 mod common;
 
 mod serde_ {
@@ -62,7 +61,7 @@ const TEST_DIR: &str = "../../test_vectors/compute_kzg_proof";
 fn test_compute_kzg_proof() {
     let test_files = collect_test_files(TEST_DIR).expect("unable to collect test files");
 
-    let ctx = tbd::Context::default();
+    let ctx = eip4844::Context::default();
 
     for test_file in test_files {
         let yaml_data = fs::read_to_string(test_file).expect("unable to read test file");

--- a/crates/eip4844/tests/compute_kzg_proof.rs
+++ b/crates/eip4844/tests/compute_kzg_proof.rs
@@ -1,0 +1,100 @@
+use std::fs;
+
+use common::collect_test_files;
+use serde_::TestVector;
+use tbd::constants::{BYTES_PER_BLOB, BYTES_PER_FIELD_ELEMENT};
+
+#[path = "../../eip7594/tests/common.rs"]
+mod common;
+
+mod serde_ {
+
+    use serde::Deserialize;
+
+    use super::common::{bytes_from_hex, UnsafeBytes};
+
+    #[derive(Deserialize)]
+    struct YamlInput {
+        blob: String,
+        z: String,
+    }
+
+    type YamlOutput = [String; 2];
+
+    #[derive(Deserialize)]
+    struct YamlTestVector {
+        input: YamlInput,
+        output: Option<YamlOutput>,
+    }
+
+    pub struct TestVector {
+        pub blob: UnsafeBytes,
+        pub z: UnsafeBytes,
+        pub output: Option<[UnsafeBytes; 2]>,
+    }
+
+    impl TestVector {
+        pub fn from_str(yaml_data: &str) -> Self {
+            let yaml_test_vector: YamlTestVector =
+                serde_yaml::from_str(yaml_data).expect("invalid yaml");
+            Self::from(yaml_test_vector)
+        }
+    }
+
+    impl From<YamlTestVector> for TestVector {
+        fn from(yaml_test_vector: YamlTestVector) -> Self {
+            let blob = yaml_test_vector.input.blob;
+            let z = yaml_test_vector.input.z;
+            let output = yaml_test_vector.output;
+
+            let blob = bytes_from_hex(&blob);
+            let z = bytes_from_hex(&z);
+
+            let output = output.map(|output| output.map(|output| bytes_from_hex(&output)));
+
+            Self { blob, z, output }
+        }
+    }
+}
+
+const TEST_DIR: &str = "../../test_vectors/compute_kzg_proof";
+#[test]
+fn test_compute_kzg_proof() {
+    let test_files = collect_test_files(TEST_DIR).expect("unable to collect test files");
+
+    let ctx = tbd::Context::default();
+
+    for test_file in test_files {
+        let yaml_data = fs::read_to_string(test_file).expect("unable to read test file");
+        let test = TestVector::from_str(&yaml_data);
+
+        let blob: &[u8; BYTES_PER_BLOB] = if let Ok(blob) = (&test.blob[..]).try_into() {
+            blob
+        } else {
+            // Blob does not have a valid size
+            assert!(test.output.is_none());
+            continue;
+        };
+
+        let z: [u8; BYTES_PER_FIELD_ELEMENT] = if let Ok(z) = test.z.try_into() {
+            z
+        } else {
+            // z does not have a valid size
+            assert!(test.output.is_none());
+            continue;
+        };
+
+        match ctx.compute_kzg_proof(blob, z) {
+            Ok((proof, evaluation)) => {
+                let [expected_proof, expected_evaluation] = test.output.expect("output is none");
+
+                assert_eq!(&proof[..], &expected_proof);
+                assert_eq!(&evaluation[..], &expected_evaluation);
+            }
+            Err(_) => {
+                // On an error, we expect the output to be null
+                assert!(test.output.is_none());
+            }
+        }
+    }
+}

--- a/crates/eip4844/tests/verify_blob_kzg_proof.rs
+++ b/crates/eip4844/tests/verify_blob_kzg_proof.rs
@@ -1,0 +1,119 @@
+use std::fs;
+
+use common::collect_test_files;
+use serde_::TestVector;
+use tbd::{
+    constants::{BYTES_PER_BLOB, BYTES_PER_COMMITMENT},
+    Error, VerifierError,
+};
+
+#[path = "../../eip7594/tests/common.rs"]
+mod common;
+
+mod serde_ {
+
+    use serde::Deserialize;
+
+    use super::common::{bytes_from_hex, UnsafeBytes};
+
+    #[derive(Deserialize)]
+    struct YamlInput {
+        blob: String,
+        commitment: String,
+        proof: String,
+    }
+
+    type YamlOutput = bool;
+
+    #[derive(Deserialize)]
+    struct YamlTestVector {
+        input: YamlInput,
+        output: Option<YamlOutput>,
+    }
+
+    pub struct TestVector {
+        pub blob: UnsafeBytes,
+        pub commitment: UnsafeBytes,
+        pub proof: UnsafeBytes,
+        pub output: Option<bool>,
+    }
+
+    impl TestVector {
+        pub fn from_str(yaml_data: &str) -> Self {
+            let yaml_test_vector: YamlTestVector =
+                serde_yaml::from_str(yaml_data).expect("invalid yaml");
+            Self::from(yaml_test_vector)
+        }
+    }
+
+    impl From<YamlTestVector> for TestVector {
+        fn from(yaml_test_vector: YamlTestVector) -> Self {
+            let blob = yaml_test_vector.input.blob;
+            let commitment = yaml_test_vector.input.commitment;
+            let proof = yaml_test_vector.input.proof;
+            let output = yaml_test_vector.output;
+
+            let blob = bytes_from_hex(&blob);
+            let commitment = bytes_from_hex(&commitment);
+            let proof = bytes_from_hex(&proof);
+
+            Self {
+                blob,
+                commitment,
+                proof,
+                output,
+            }
+        }
+    }
+}
+
+const TEST_DIR: &str = "../../test_vectors/verify_blob_kzg_proof";
+#[test]
+fn test_verify_blob_kzg_proof() {
+    let test_files = collect_test_files(TEST_DIR).expect("unable to collect test files");
+
+    let ctx = tbd::Context::default();
+
+    for test_file in test_files {
+        let yaml_data = fs::read_to_string(test_file).expect("unable to read test file");
+        let test = TestVector::from_str(&yaml_data);
+
+        let blob: &[u8; BYTES_PER_BLOB] = if let Ok(blob) = (&test.blob[..]).try_into() {
+            blob
+        } else {
+            // Blob does not have a valid size
+            assert!(test.output.is_none());
+            continue;
+        };
+
+        let commitment: [u8; BYTES_PER_COMMITMENT] =
+            if let Ok(commitment) = test.commitment.try_into() {
+                commitment
+            } else {
+                // Commitment does not have a valid size
+                assert!(test.output.is_none());
+                continue;
+            };
+
+        let proof: [u8; BYTES_PER_COMMITMENT] = if let Ok(proof) = test.proof.try_into() {
+            proof
+        } else {
+            // Proof does not have a valid size
+            assert!(test.output.is_none());
+            continue;
+        };
+
+        match ctx.verify_blob_kzg_proof(blob, commitment, proof) {
+            Ok(()) => {
+                // We arrive at this point if the proof verified as true
+                assert!(test.output.unwrap());
+            }
+            Err(Error::Verifier(VerifierError::InvalidProof)) => {
+                assert!(!test.output.unwrap());
+            }
+            Err(_) => {
+                assert!(test.output.is_none());
+            }
+        }
+    }
+}

--- a/crates/eip4844/tests/verify_blob_kzg_proof.rs
+++ b/crates/eip4844/tests/verify_blob_kzg_proof.rs
@@ -1,13 +1,12 @@
 use std::fs;
 
 use common::collect_test_files;
-use serde_::TestVector;
-use tbd::{
+use eip4844::{
     constants::{BYTES_PER_BLOB, BYTES_PER_COMMITMENT},
     Error, VerifierError,
 };
+use serde_::TestVector;
 
-#[path = "../../eip7594/tests/common.rs"]
 mod common;
 
 mod serde_ {
@@ -72,7 +71,7 @@ const TEST_DIR: &str = "../../test_vectors/verify_blob_kzg_proof";
 fn test_verify_blob_kzg_proof() {
     let test_files = collect_test_files(TEST_DIR).expect("unable to collect test files");
 
-    let ctx = tbd::Context::default();
+    let ctx = eip4844::Context::default();
 
     for test_file in test_files {
         let yaml_data = fs::read_to_string(test_file).expect("unable to read test file");

--- a/crates/eip4844/tests/verify_blob_kzg_proof_batch.rs
+++ b/crates/eip4844/tests/verify_blob_kzg_proof_batch.rs
@@ -1,0 +1,127 @@
+use std::fs;
+
+use common::collect_test_files;
+use serde_::TestVector;
+use tbd::{constants::BYTES_PER_BLOB, Error, KZGCommitment, KZGProof, VerifierError};
+
+#[path = "../../eip7594/tests/common.rs"]
+mod common;
+
+mod serde_ {
+
+    use serde::Deserialize;
+
+    use super::common::{bytes_from_hex, UnsafeBytes};
+
+    #[derive(Deserialize)]
+    struct YamlInput {
+        blobs: Vec<String>,
+        commitments: Vec<String>,
+        proofs: Vec<String>,
+    }
+
+    type YamlOutput = bool;
+
+    #[derive(Deserialize)]
+    struct YamlTestVector {
+        input: YamlInput,
+        output: Option<YamlOutput>,
+    }
+
+    pub struct TestVector {
+        pub blobs: Vec<UnsafeBytes>,
+        pub commitments: Vec<UnsafeBytes>,
+        pub proofs: Vec<UnsafeBytes>,
+        pub output: Option<bool>,
+    }
+
+    impl TestVector {
+        pub fn from_str(yaml_data: &str) -> Self {
+            let yaml_test_vector: YamlTestVector =
+                serde_yaml::from_str(yaml_data).expect("invalid yaml");
+            Self::from(yaml_test_vector)
+        }
+    }
+
+    impl From<YamlTestVector> for TestVector {
+        fn from(yaml_test_vector: YamlTestVector) -> Self {
+            let blobs = yaml_test_vector.input.blobs;
+            let commitments = yaml_test_vector.input.commitments;
+            let proofs = yaml_test_vector.input.proofs;
+            let output = yaml_test_vector.output;
+
+            let blobs = blobs.iter().map(|blob| bytes_from_hex(blob)).collect();
+            let commitments = commitments
+                .iter()
+                .map(|commitment| bytes_from_hex(commitment))
+                .collect();
+            let proofs = proofs.iter().map(|proof| bytes_from_hex(proof)).collect();
+
+            Self {
+                blobs,
+                commitments,
+                proofs,
+                output,
+            }
+        }
+    }
+}
+
+const TEST_DIR: &str = "../../test_vectors/verify_blob_kzg_proof_batch";
+#[test]
+fn test_verify_blob_kzg_proof_batch() {
+    let test_files = collect_test_files(TEST_DIR).expect("unable to collect test files");
+
+    let ctx = tbd::Context::default();
+
+    for test_file in test_files {
+        let yaml_data = fs::read_to_string(test_file).expect("unable to read test file");
+        let test = TestVector::from_str(&yaml_data);
+
+        let Ok(blobs) = test
+            .blobs
+            .iter()
+            .map(|blob| <&[u8; BYTES_PER_BLOB]>::try_from(blob.as_slice()))
+            .collect::<Result<Vec<_>, _>>()
+        else {
+            // Blob does not have a valid size
+            assert!(test.output.is_none());
+            continue;
+        };
+
+        let Ok(commitments) = test
+            .commitments
+            .iter()
+            .map(|commitment| KZGCommitment::try_from(commitment.as_slice()))
+            .collect::<Result<Vec<_>, _>>()
+        else {
+            // Commitment does not have a valid size
+            assert!(test.output.is_none());
+            continue;
+        };
+
+        let Ok(proofs) = test
+            .proofs
+            .iter()
+            .map(|proof| KZGProof::try_from(proof.as_slice()))
+            .collect::<Result<Vec<_>, _>>()
+        else {
+            // Proof does not have a valid size
+            assert!(test.output.is_none());
+            continue;
+        };
+
+        match ctx.verify_blob_kzg_proof_batch(&blobs, &commitments, &proofs) {
+            Ok(()) => {
+                // We arrive at this point if the proof verified as true
+                assert!(test.output.unwrap());
+            }
+            Err(Error::Verifier(VerifierError::InvalidProof)) => {
+                assert!(!test.output.unwrap());
+            }
+            Err(_) => {
+                assert!(test.output.is_none());
+            }
+        }
+    }
+}

--- a/crates/eip4844/tests/verify_blob_kzg_proof_batch.rs
+++ b/crates/eip4844/tests/verify_blob_kzg_proof_batch.rs
@@ -1,10 +1,9 @@
 use std::fs;
 
 use common::collect_test_files;
+use eip4844::{constants::BYTES_PER_BLOB, Error, KZGCommitment, KZGProof, VerifierError};
 use serde_::TestVector;
-use tbd::{constants::BYTES_PER_BLOB, Error, KZGCommitment, KZGProof, VerifierError};
 
-#[path = "../../eip7594/tests/common.rs"]
 mod common;
 
 mod serde_ {
@@ -72,7 +71,7 @@ const TEST_DIR: &str = "../../test_vectors/verify_blob_kzg_proof_batch";
 fn test_verify_blob_kzg_proof_batch() {
     let test_files = collect_test_files(TEST_DIR).expect("unable to collect test files");
 
-    let ctx = tbd::Context::default();
+    let ctx = eip4844::Context::default();
 
     for test_file in test_files {
         let yaml_data = fs::read_to_string(test_file).expect("unable to read test file");

--- a/crates/eip4844/tests/verify_kzg_proof.rs
+++ b/crates/eip4844/tests/verify_kzg_proof.rs
@@ -1,13 +1,12 @@
 use std::fs;
 
 use common::collect_test_files;
-use serde_::TestVector;
-use tbd::{
+use eip4844::{
     constants::{BYTES_PER_COMMITMENT, BYTES_PER_FIELD_ELEMENT},
     Error, VerifierError,
 };
+use serde_::TestVector;
 
-#[path = "../../eip7594/tests/common.rs"]
 mod common;
 
 mod serde_ {
@@ -77,7 +76,7 @@ const TEST_DIR: &str = "../../test_vectors/verify_kzg_proof";
 fn test_verify_kzg_proof() {
     let test_files = collect_test_files(TEST_DIR).expect("unable to collect test files");
 
-    let ctx = tbd::Context::default();
+    let ctx = eip4844::Context::default();
 
     for test_file in test_files {
         let yaml_data = fs::read_to_string(test_file).expect("unable to read test file");

--- a/crates/eip4844/tests/verify_kzg_proof.rs
+++ b/crates/eip4844/tests/verify_kzg_proof.rs
@@ -1,0 +1,132 @@
+use std::fs;
+
+use common::collect_test_files;
+use serde_::TestVector;
+use tbd::{
+    constants::{BYTES_PER_COMMITMENT, BYTES_PER_FIELD_ELEMENT},
+    Error, VerifierError,
+};
+
+#[path = "../../eip7594/tests/common.rs"]
+mod common;
+
+mod serde_ {
+
+    use serde::Deserialize;
+
+    use super::common::{bytes_from_hex, UnsafeBytes};
+
+    #[derive(Deserialize)]
+    struct YamlInput {
+        commitment: String,
+        z: String,
+        y: String,
+        proof: String,
+    }
+
+    type YamlOutput = bool;
+
+    #[derive(Deserialize)]
+    struct YamlTestVector {
+        input: YamlInput,
+        output: Option<YamlOutput>,
+    }
+
+    pub struct TestVector {
+        pub commitment: UnsafeBytes,
+        pub z: UnsafeBytes,
+        pub y: UnsafeBytes,
+        pub proof: UnsafeBytes,
+        pub output: Option<bool>,
+    }
+
+    impl TestVector {
+        pub fn from_str(yaml_data: &str) -> Self {
+            let yaml_test_vector: YamlTestVector =
+                serde_yaml::from_str(yaml_data).expect("invalid yaml");
+            Self::from(yaml_test_vector)
+        }
+    }
+
+    impl From<YamlTestVector> for TestVector {
+        fn from(yaml_test_vector: YamlTestVector) -> Self {
+            let commitment = yaml_test_vector.input.commitment;
+            let z = yaml_test_vector.input.z;
+            let y = yaml_test_vector.input.y;
+            let proof = yaml_test_vector.input.proof;
+            let output = yaml_test_vector.output;
+
+            let commitment = bytes_from_hex(&commitment);
+            let z = bytes_from_hex(&z);
+            let y = bytes_from_hex(&y);
+            let proof = bytes_from_hex(&proof);
+
+            Self {
+                commitment,
+                z,
+                y,
+                proof,
+                output,
+            }
+        }
+    }
+}
+
+const TEST_DIR: &str = "../../test_vectors/verify_kzg_proof";
+#[test]
+fn test_verify_kzg_proof() {
+    let test_files = collect_test_files(TEST_DIR).expect("unable to collect test files");
+
+    let ctx = tbd::Context::default();
+
+    for test_file in test_files {
+        let yaml_data = fs::read_to_string(test_file).expect("unable to read test file");
+        let test = TestVector::from_str(&yaml_data);
+
+        let commitment: [u8; BYTES_PER_COMMITMENT] =
+            if let Ok(commitment) = test.commitment.try_into() {
+                commitment
+            } else {
+                // Commitment does not have a valid size
+                assert!(test.output.is_none());
+                continue;
+            };
+
+        let z: [u8; BYTES_PER_FIELD_ELEMENT] = if let Ok(z) = test.z.try_into() {
+            z
+        } else {
+            // Point does not have a valid size
+            assert!(test.output.is_none());
+            continue;
+        };
+
+        let y: [u8; BYTES_PER_FIELD_ELEMENT] = if let Ok(y) = test.y.try_into() {
+            y
+        } else {
+            // Evaluation does not have a valid size
+            assert!(test.output.is_none());
+            continue;
+        };
+
+        let proof: [u8; BYTES_PER_COMMITMENT] = if let Ok(proof) = test.proof.try_into() {
+            proof
+        } else {
+            // Proof does not have a valid size
+            assert!(test.output.is_none());
+            continue;
+        };
+
+        match ctx.verify_kzg_proof(commitment, z, y, proof) {
+            Ok(()) => {
+                // We arrive at this point if the proof verified as true
+                assert!(test.output.unwrap());
+            }
+            Err(Error::Verifier(VerifierError::InvalidProof)) => {
+                assert!(!test.output.unwrap());
+            }
+            Err(_) => {
+                assert!(test.output.is_none());
+            }
+        }
+    }
+}

--- a/crates/eip7594/Cargo.toml
+++ b/crates/eip7594/Cargo.toml
@@ -24,7 +24,7 @@ tracing = { version = "0.1.41", default-features = false, features = ["attribute
 [features]
 singlethreaded = ["kzg_multi_open/singlethreaded"]
 multithreaded = ["rayon", "kzg_multi_open/multithreaded"]
-tracing = ["dep:tracing", "bls12_381/tracing", "kzg_multi_open/tracing"]
+tracing = ["dep:tracing", "kzg_multi_open/tracing"]
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/crates/eip7594/src/trusted_setup.rs
+++ b/crates/eip7594/src/trusted_setup.rs
@@ -37,7 +37,7 @@ impl Default for TrustedSetup {
 
 /// An enum used to specify whether to check that the points are in the correct subgroup
 #[derive(Debug, Copy, Clone)]
-enum SubgroupCheck {
+pub(crate) enum SubgroupCheck {
     Check,
     NoCheck,
 }
@@ -128,7 +128,7 @@ impl TrustedSetup {
 
 /// Deserialize G1 points from hex strings without checking that the element
 /// is in the correct subgroup.
-fn deserialize_g1_points<T: AsRef<str>>(
+pub(crate) fn deserialize_g1_points<T: AsRef<str>>(
     g1_points_hex_str: &[T],
     check: SubgroupCheck,
 ) -> Vec<G1Point> {
@@ -161,7 +161,7 @@ fn deserialize_g1_points<T: AsRef<str>>(
 
 /// Deserialize G2 points from hex strings without checking that the element
 /// is in the correct subgroup.
-fn deserialize_g2_points<T: AsRef<str>>(
+pub(crate) fn deserialize_g2_points<T: AsRef<str>>(
     g2_points_hex_str: &[T],
     subgroup_check: SubgroupCheck,
 ) -> Vec<G2Point> {

--- a/crates/eip7594/src/trusted_setup.rs
+++ b/crates/eip7594/src/trusted_setup.rs
@@ -37,7 +37,7 @@ impl Default for TrustedSetup {
 
 /// An enum used to specify whether to check that the points are in the correct subgroup
 #[derive(Debug, Copy, Clone)]
-pub(crate) enum SubgroupCheck {
+enum SubgroupCheck {
     Check,
     NoCheck,
 }
@@ -128,7 +128,7 @@ impl TrustedSetup {
 
 /// Deserialize G1 points from hex strings without checking that the element
 /// is in the correct subgroup.
-pub(crate) fn deserialize_g1_points<T: AsRef<str>>(
+fn deserialize_g1_points<T: AsRef<str>>(
     g1_points_hex_str: &[T],
     check: SubgroupCheck,
 ) -> Vec<G1Point> {
@@ -161,7 +161,7 @@ pub(crate) fn deserialize_g1_points<T: AsRef<str>>(
 
 /// Deserialize G2 points from hex strings without checking that the element
 /// is in the correct subgroup.
-pub(crate) fn deserialize_g2_points<T: AsRef<str>>(
+fn deserialize_g2_points<T: AsRef<str>>(
     g2_points_hex_str: &[T],
     subgroup_check: SubgroupCheck,
 ) -> Vec<G2Point> {


### PR DESCRIPTION
Adding EIP4844 APIs and tests.

Now it uses very ugly way to get the constant, method and structures of  `constants.rs`, `serialization.rs` and `trusted_setup.rs` in crate `eip7594`, it'd be much better to refactor these common utilities into another crate for reuse.
