### PR TITLE
chore: unify `fft_inplace`

### DIFF
--- a/crates/cryptography/polynomial/src/domain.rs
+++ b/crates/cryptography/polynomial/src/domain.rs
@@ -6,7 +6,7 @@ use bls12_381::{
 
 use crate::{
     coset_fft::CosetFFT,
-    fft::{fft_g1_inplace, fft_scalar_inplace, precompute_omegas, precompute_twiddle_factors_bo},
+    fft::{fft_inplace, precompute_omegas, precompute_twiddle_factors_bo},
     poly_coeff::PolyCoeff,
 };
 
@@ -123,7 +123,7 @@ impl Domain {
         // domain.
         polynomial.resize(self.size(), Scalar::ZERO);
 
-        fft_scalar_inplace(&self.omegas, &self.twiddle_factors_bo, &mut polynomial);
+        fft_inplace(&self.omegas, &self.twiddle_factors_bo, &mut polynomial);
 
         polynomial
     }
@@ -140,7 +140,7 @@ impl Domain {
             *point *= coset_scale;
             coset_scale *= coset.generator;
         }
-        fft_scalar_inplace(&self.omegas, &self.twiddle_factors_bo, &mut points);
+        fft_inplace(&self.omegas, &self.twiddle_factors_bo, &mut points);
 
         points
     }
@@ -155,7 +155,7 @@ impl Domain {
         // domain.
         points.resize(self.size(), G1Projective::identity());
 
-        fft_g1_inplace(&self.omegas, &self.twiddle_factors_bo, &mut points);
+        fft_inplace(&self.omegas, &self.twiddle_factors_bo, &mut points);
 
         points
     }
@@ -182,7 +182,7 @@ impl Domain {
         // domain.
         points.resize(self.size(), G1Projective::identity());
 
-        fft_g1_inplace(&self.omegas_inv, &self.twiddle_factors_inv_bo, &mut points);
+        fft_inplace(&self.omegas_inv, &self.twiddle_factors_inv_bo, &mut points);
 
         // Truncate the result if a value of `n` was supplied.
         let out_len = n.unwrap_or(points.len());
@@ -205,7 +205,7 @@ impl Domain {
         // domain.
         points.resize(self.size(), Scalar::ZERO);
 
-        fft_scalar_inplace(&self.omegas_inv, &self.twiddle_factors_inv_bo, &mut points);
+        fft_inplace(&self.omegas_inv, &self.twiddle_factors_inv_bo, &mut points);
 
         for element in &mut points {
             *element *= self.domain_size_inv;

--- a/crates/cryptography/polynomial/src/fft.rs
+++ b/crates/cryptography/polynomial/src/fft.rs
@@ -6,7 +6,7 @@ use std::{
 use bls12_381::{ff::Field, group::Group, G1Projective, Scalar};
 use maybe_rayon::prelude::*;
 
-trait FFTElement:
+pub(crate) trait FFTElement:
     Sized
     + Send
     + Copy
@@ -33,7 +33,11 @@ impl FFTElement for G1Projective {
 }
 
 // Taken and modified from https://github.com/Plonky3/Plonky3/blob/a374139/dft/src/radix_2_dit_parallel.rs#L106.
-fn fft_inplace<T: FFTElement>(omegas: &[Scalar], twiddle_factors_bo: &[Scalar], values: &mut [T]) {
+pub(crate) fn fft_inplace<T: FFTElement>(
+    omegas: &[Scalar],
+    twiddle_factors_bo: &[Scalar],
+    values: &mut [T],
+) {
     let log_n = log2_pow2(values.len()) as usize;
     let mid = log_n.div_ceil(2);
 
@@ -138,22 +142,6 @@ fn dit<T: FFTElement>(a: &mut T, b: &mut T, twiddle: Scalar) {
     *b = *a;
     *a = *a + t;
     *b = *b - t;
-}
-
-pub(crate) fn fft_scalar_inplace(
-    twiddle_factors: &[Scalar],
-    twiddle_factors_bo: &[Scalar],
-    a: &mut [Scalar],
-) {
-    fft_inplace(twiddle_factors, twiddle_factors_bo, a);
-}
-
-pub(crate) fn fft_g1_inplace(
-    twiddle_factors: &[Scalar],
-    twiddle_factors_bo: &[Scalar],
-    a: &mut [G1Projective],
-) {
-    fft_inplace(twiddle_factors, twiddle_factors_bo, a);
 }
 
 fn bitreverse(mut n: u32, l: u32) -> u32 {


### PR DESCRIPTION
@kevaundray As `fft_g1_inplace` and `fft_scalar_inplace` shared exactly the same logic, they are removed to expose directly `fft_inplace` and simplify the usage from a user perspective. Let me know what you think about this?