### PR TITLE
chore: small reorg of eip7594 recovery and unit tests

### DIFF
--- a/crates/cryptography/kzg_multi_open/src/fk20/verifier.rs
+++ b/crates/cryptography/kzg_multi_open/src/fk20/verifier.rs
@@ -310,8 +310,6 @@ fn compute_fiat_shamir_challenge(
 ///
 /// Example: compute_powers(x, 5) = [1, x, x^2, x^3, x^4]
 fn compute_powers(value: Scalar, num_elements: usize) -> Vec<Scalar> {
-    use bls12_381::ff::Field;
-
     let mut powers = Vec::with_capacity(num_elements);
     let mut current_power = Scalar::ONE;
 

--- a/crates/eip7594/src/errors.rs
+++ b/crates/eip7594/src/errors.rs
@@ -42,6 +42,12 @@ impl From<RecoveryError> for Error {
     }
 }
 
+impl From<RSError> for Error {
+    fn from(value: RSError) -> Self {
+        Self::Recovery(RecoveryError::ReedSolomon(value))
+    }
+}
+
 /// Errors that can occur while calling a method in the Prover API
 #[derive(Debug)]
 pub enum ProverError {

--- a/crates/eip7594/src/lib.rs
+++ b/crates/eip7594/src/lib.rs
@@ -16,15 +16,16 @@ pub use errors::Error;
 /// TrustedSetup contains the Structured Reference String(SRS)
 /// needed to make and verify proofs.
 pub use trusted_setup::TrustedSetup;
-/// BlobRef denotes a references to an opaque Blob.
+
+/// `BlobRef` denotes a references to an opaque Blob.
 ///
 /// Note: This library never returns a Blob, which is why we
 /// do not have a Blob type.
 pub type BlobRef<'a> = &'a [u8; BYTES_PER_BLOB];
 
-/// Bytes48Ref denotes a reference to an untrusted cryptographic type
+/// `Bytes48Ref` denotes a reference to an untrusted cryptographic type
 /// that can be represented in 48 bytes. This will be either a
-/// purported KZGProof or a purported KZGCommitment.
+/// purported `KZGProof` or a purported `KZGCommitment`.
 pub type Bytes48Ref<'a> = &'a [u8; 48];
 
 /// Cell contains a group of evaluations on a coset that one would like to
@@ -33,22 +34,22 @@ pub type Bytes48Ref<'a> = &'a [u8; 48];
 /// Note: These are heap allocated.
 pub type Cell = Box<[u8; BYTES_PER_CELL]>;
 
-/// CellRef contains a reference to a Cell.
+/// `CellRef` contains a reference to a Cell.
 ///
 /// Note: Similar to Blob, the library takes in references
 /// to Cell and returns heap allocated instances as return types.
 pub type CellRef<'a> = &'a [u8; BYTES_PER_CELL];
 
-/// KZGProof denotes a 48 byte commitment to a polynomial
+/// `KZGProof` denotes a 48 byte commitment to a polynomial
 /// that one can use to prove that a polynomial f(x) was
 /// correctly evaluated on a coset `H` and returned a set of points.
 pub type KZGProof = [u8; BYTES_PER_COMMITMENT];
 
-/// KZGCommitment denotes a 48 byte commitment to a polynomial f(x)
+/// `KZGCommitment` denotes a 48 byte commitment to a polynomial f(x)
 /// that we would like to make and verify opening proofs about.
 pub type KZGCommitment = [u8; BYTES_PER_COMMITMENT];
 
-/// CellIndex is reference to the coset/set of points that were used to create that Cell,
+/// `CellIndex` is reference to the coset/set of points that were used to create that Cell,
 /// on a particular polynomial, f(x).
 ///
 /// Note: Since the verifier and prover both know what cosets will be used

--- a/crates/eip7594/src/recovery.rs
+++ b/crates/eip7594/src/recovery.rs
@@ -54,10 +54,7 @@ pub(crate) fn recover_polynomial_coeff(
         .expect("infallible: could not recover evaluations in domain order");
 
     // Find all of the missing cell indices. This is needed for recovery.
-    let present_cell_indices: HashSet<_> = cell_indices_normal_order.iter().copied().collect();
-    let missing_cell_indices = (0..CELLS_PER_EXT_BLOB)
-        .filter(|i| !present_cell_indices.contains(i))
-        .collect();
+let missing_cell_indices = find_missing_cell_indices(&cell_indices_normal_order);
 
     // Recover the polynomial in monomial form, that one can use to generate the cells.
     let recovered_polynomial_coeff = rs.recover_polynomial_coefficient(

--- a/crates/eip7594/src/recovery.rs
+++ b/crates/eip7594/src/recovery.rs
@@ -65,6 +65,15 @@ let missing_cell_indices = find_missing_cell_indices(&cell_indices_normal_order)
     Ok(recovered_polynomial_coeff)
 }
 
+#[inline]
+fn find_missing_cell_indices(present_cell_indices: &[usize]) -> Vec<usize> {
+    let cell_indices: HashSet<_> = present_cell_indices.iter().copied().collect();
+
+    (0..CELLS_PER_EXT_BLOB)
+        .filter(|i| !cell_indices.contains(i))
+        .collect()
+}
+
 /// Validates that the given cell indices and cell data are suitable for polynomial recovery.
 ///
 /// Checks the following:

--- a/crates/eip7594/src/recovery.rs
+++ b/crates/eip7594/src/recovery.rs
@@ -5,25 +5,31 @@ use erasure_codes::{BlockErasureIndices, ReedSolomon};
 use kzg_multi_open::recover_evaluations_in_domain_order;
 
 use crate::{
-    constants::{CELLS_PER_EXT_BLOB, FIELD_ELEMENTS_PER_EXT_BLOB},
+    constants::{
+        BYTES_PER_CELL, CELLS_PER_EXT_BLOB, EXPANSION_FACTOR, FIELD_ELEMENTS_PER_EXT_BLOB,
+    },
     errors::{Error, RecoveryError},
     serialization::deserialize_cells,
     CellIndex, CellRef,
 };
 
+/// Recovers the original polynomial coefficients from a subset of encoded cells.
+///
+/// Takes a list of cell indices and their corresponding data, verifies the inputs,
+/// reorders the evaluations, and performs Reed-Solomon recovery to reconstruct the polynomial.
+///
+/// Returns the full set of coefficients if successful, or an error if validation or recovery fails.
 pub(crate) fn recover_polynomial_coeff(
     rs: &ReedSolomon,
     cell_indices: Vec<CellIndex>,
     cells: Vec<CellRef>,
 ) -> Result<Vec<Scalar>, Error> {
     // Validation
-    //
-    validation::recover_polynomial_coeff(&cell_indices, &cells)?;
+    validate_recovery_inputs(&cell_indices, &cells)?;
 
     // Deserialization
-    //
     let coset_evaluations = deserialize_cells(cells)?;
-    let cell_indices: Vec<usize> = cell_indices
+    let cell_indices: Vec<_> = cell_indices
         .into_iter()
         .map(|index| index as usize)
         .collect();
@@ -48,116 +54,185 @@ pub(crate) fn recover_polynomial_coeff(
         .expect("infallible: could not recover evaluations in domain order");
 
     // Find all of the missing cell indices. This is needed for recovery.
-    let missing_cell_indices = find_missing_cell_indices(&cell_indices_normal_order);
+    let present_cell_indices: HashSet<_> = cell_indices_normal_order.iter().copied().collect();
+    let missing_cell_indices = (0..CELLS_PER_EXT_BLOB)
+        .filter(|i| !present_cell_indices.contains(i))
+        .collect();
 
     // Recover the polynomial in monomial form, that one can use to generate the cells.
-    let recovered_polynomial_coeff = rs
-        .recover_polynomial_coefficient(
-            flattened_coset_evaluations_normal_order,
-            BlockErasureIndices(missing_cell_indices),
-        )
-        .map_err(RecoveryError::from)?;
+    let recovered_polynomial_coeff = rs.recover_polynomial_coefficient(
+        flattened_coset_evaluations_normal_order,
+        BlockErasureIndices(missing_cell_indices),
+    )?;
 
     Ok(recovered_polynomial_coeff)
 }
 
-fn find_missing_cell_indices(present_cell_indices: &[usize]) -> Vec<usize> {
-    let cell_indices: HashSet<_> = present_cell_indices.iter().copied().collect();
+/// Validates that the given cell indices and cell data are suitable for polynomial recovery.
+///
+/// Checks the following:
+/// - Each index has a corresponding cell (`len(indices) == len(cells)`).
+/// - All indices are within `[0, CELLS_PER_EXT_BLOB)`.
+/// - Each cell has exactly `BYTES_PER_CELL` bytes.
+/// - No duplicate indices are present.
+/// - There are enough cells to reconstruct the data (`≥ CELLS_PER_EXT_BLOB / EXPANSION_FACTOR`).
+/// - There are not too many cells (`≤ CELLS_PER_EXT_BLOB`).
+///
+/// Returns `Ok(())` if all checks pass, or a `RecoveryError` if any condition fails.
+///
+/// Panics if a cell does not have the expected byte length (infallible under correct construction).
+pub(crate) fn validate_recovery_inputs(
+    cell_indices: &[CellIndex],
+    cells: &[CellRef],
+) -> Result<(), RecoveryError> {
+    // Check that the number of cell indices is equal to the number of cells
+    if cell_indices.len() != cells.len() {
+        return Err(RecoveryError::NumCellIndicesNotEqualToNumCells {
+            num_cell_indices: cell_indices.len(),
+            num_cells: cells.len(),
+        });
+    }
 
-    (0..CELLS_PER_EXT_BLOB)
-        .filter(|i| !cell_indices.contains(i))
-        .collect()
+    // Check that the Cell indices are within the expected range
+    for &cell_index in cell_indices {
+        if cell_index >= (CELLS_PER_EXT_BLOB as u64) {
+            return Err(RecoveryError::CellIndexOutOfRange {
+                cell_index,
+                max_number_of_cells: CELLS_PER_EXT_BLOB as u64,
+            });
+        }
+    }
+
+    // Check that each cell has the right amount of bytes
+    //
+    // This should be infallible.
+    for (i, cell) in cells.iter().enumerate() {
+        assert_eq!(cell.len(), BYTES_PER_CELL, "the number of bytes in a cell should always equal {BYTES_PER_CELL} since the type is a reference to an array. Check cell at index {i}");
+    }
+
+    // Check that we have no duplicate cell indices
+    if !are_cell_indices_unique(cell_indices) {
+        return Err(RecoveryError::CellIndicesNotUnique);
+    }
+
+    // Check that we have enough cells to perform a reconstruction
+    if cell_indices.len() < CELLS_PER_EXT_BLOB / EXPANSION_FACTOR {
+        return Err(RecoveryError::NotEnoughCellsToReconstruct {
+            num_cells_received: cell_indices.len(),
+            min_cells_needed: CELLS_PER_EXT_BLOB / EXPANSION_FACTOR,
+        });
+    }
+
+    // Check that we don't have too many cells,
+    // i.e. more than we initially generated from the blob.
+    //
+    // Note: Since we check that there are no duplicates and that all `cell_indices`
+    // are between 0 and `CELLS_PER_EXT_BLOB`, this check should never fail.
+    // It is kept here to be compliant with the specs.
+    if cell_indices.len() > CELLS_PER_EXT_BLOB {
+        return Err(RecoveryError::TooManyCellsReceived {
+            num_cells_received: cell_indices.len(),
+            max_cells_needed: CELLS_PER_EXT_BLOB,
+        });
+    }
+
+    Ok(())
 }
 
-mod validation {
-    use std::collections::HashSet;
+/// Check if all of the cell indices are unique
+fn are_cell_indices_unique(cell_indices: &[CellIndex]) -> bool {
+    let mut seen = HashSet::with_capacity(cell_indices.len());
+    cell_indices.iter().all(|idx| seen.insert(idx))
+}
 
-    use crate::{
-        constants::{BYTES_PER_CELL, CELLS_PER_EXT_BLOB, EXPANSION_FACTOR},
-        errors::RecoveryError,
-        CellIndex, CellRef,
-    };
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    /// Validation logic for `recover_polynomial_coeff`
-    pub(crate) fn recover_polynomial_coeff(
-        cell_indices: &[CellIndex],
-        cells: &[CellRef],
-    ) -> Result<(), RecoveryError> {
-        // Check that the number of cell indices is equal to the number of cells
-        if cell_indices.len() != cells.len() {
-            return Err(RecoveryError::NumCellIndicesNotEqualToNumCells {
-                num_cell_indices: cell_indices.len(),
-                num_cells: cells.len(),
-            });
-        }
-
-        // Check that the Cell indices are within the expected range
-        for cell_index in cell_indices {
-            if *cell_index >= (CELLS_PER_EXT_BLOB as u64) {
-                return Err(RecoveryError::CellIndexOutOfRange {
-                    cell_index: *cell_index,
-                    max_number_of_cells: CELLS_PER_EXT_BLOB as u64,
-                });
-            }
-        }
-
-        // Check that each cell has the right amount of bytes
-        //
-        // This should be infallible.
-        for (i, cell) in cells.iter().enumerate() {
-            assert_eq!(cell.len(), BYTES_PER_CELL, "the number of bytes in a cell should always equal {BYTES_PER_CELL} since the type is a reference to an array. Check cell at index {i}");
-        }
-
-        // Check that we have no duplicate cell indices
-        if !are_cell_indices_unique(cell_indices) {
-            return Err(RecoveryError::CellIndicesNotUnique);
-        }
-
-        // Check that we have enough cells to perform a reconstruction
-        if cell_indices.len() < CELLS_PER_EXT_BLOB / EXPANSION_FACTOR {
-            return Err(RecoveryError::NotEnoughCellsToReconstruct {
-                num_cells_received: cell_indices.len(),
-                min_cells_needed: CELLS_PER_EXT_BLOB / EXPANSION_FACTOR,
-            });
-        }
-
-        // Check that we don't have too many cells
-        // ie more than we initially generated from the blob
-        //
-        // Note: Since we check that there are no duplicates and that all cell_indices
-        // are between 0 and CELLS_PER_EXT_BLOB. This check should never fail.
-        // It is kept here to be compliant with the specs.
-        if cell_indices.len() > CELLS_PER_EXT_BLOB {
-            return Err(RecoveryError::TooManyCellsReceived {
-                num_cells_received: cell_indices.len(),
-                max_cells_needed: CELLS_PER_EXT_BLOB,
-            });
-        }
-
-        Ok(())
+    /// Leak a zero-initialized cell and return a reference with fixed size.
+    fn zeroed_cell_ref() -> CellRef<'static> {
+        let boxed: Box<[u8; BYTES_PER_CELL]> = Box::new([0u8; BYTES_PER_CELL]);
+        Box::leak(boxed)
     }
 
-    /// Check if all of the cell indices are unique
-    fn are_cell_indices_unique(cell_indices: &[CellIndex]) -> bool {
-        let len_cell_indices_non_dedup = cell_indices.len();
-        let cell_indices_dedup: HashSet<_> = cell_indices.iter().collect();
-        cell_indices_dedup.len() == len_cell_indices_non_dedup
+    /// Helper: create a valid list of unique indices and cells
+    fn make_valid_inputs(min_cells: usize) -> (Vec<CellIndex>, Vec<CellRef<'static>>) {
+        let indices: Vec<CellIndex> = (0..min_cells as u64).collect();
+        let cells: Vec<CellRef> = (0..min_cells).map(|_| zeroed_cell_ref()).collect();
+        (indices, cells)
     }
 
-    #[cfg(test)]
-    mod tests {
-        use super::are_cell_indices_unique;
+    #[test]
+    fn test_cell_indices_unique() {
+        let cell_indices = vec![1, 2, 3];
+        assert!(are_cell_indices_unique(&cell_indices));
+        let cell_indices = vec![];
+        assert!(are_cell_indices_unique(&cell_indices));
+        let cell_indices = vec![1, 1, 2, 3];
+        assert!(!are_cell_indices_unique(&cell_indices));
+        let cell_indices = vec![0, 0, 0];
+        assert!(!are_cell_indices_unique(&cell_indices));
+    }
 
-        #[test]
-        fn test_cell_indices_unique() {
-            let cell_indices = vec![1, 2, 3];
-            assert!(are_cell_indices_unique(&cell_indices));
-            let cell_indices = vec![];
-            assert!(are_cell_indices_unique(&cell_indices));
-            let cell_indices = vec![1, 1, 2, 3];
-            assert!(!are_cell_indices_unique(&cell_indices));
-            let cell_indices = vec![0, 0, 0];
-            assert!(!are_cell_indices_unique(&cell_indices));
-        }
+    #[test]
+    fn test_validation_success() {
+        let min_cells = CELLS_PER_EXT_BLOB / EXPANSION_FACTOR;
+        let (indices, cells) = make_valid_inputs(min_cells);
+        assert!(validate_recovery_inputs(&indices, &cells).is_ok());
+    }
+
+    #[test]
+    fn test_mismatched_lengths() {
+        let (mut indices, cells) = make_valid_inputs(4);
+        indices.pop(); // now indices.len() != cells.len()
+        let err = validate_recovery_inputs(&indices, &cells).unwrap_err();
+        assert!(matches!(
+            err,
+            RecoveryError::NumCellIndicesNotEqualToNumCells { .. }
+        ));
+    }
+
+    #[test]
+    fn test_out_of_range_index() {
+        let (mut indices, cells) = make_valid_inputs(4);
+        indices[1] = CELLS_PER_EXT_BLOB as u64; // out-of-range index
+        let err = validate_recovery_inputs(&indices, &cells).unwrap_err();
+        assert!(matches!(err, RecoveryError::CellIndexOutOfRange { .. }));
+    }
+
+    #[test]
+    fn test_not_enough_cells() {
+        let too_few = CELLS_PER_EXT_BLOB / EXPANSION_FACTOR - 1;
+        let (indices, cells) = make_valid_inputs(too_few);
+        let err = validate_recovery_inputs(&indices, &cells).unwrap_err();
+        assert!(matches!(
+            err,
+            RecoveryError::NotEnoughCellsToReconstruct { .. }
+        ));
+    }
+
+    #[test]
+    fn test_duplicate_cell_indices() {
+        let indices = vec![0, 1, 2, 2]; // duplicate
+        let cells: Vec<CellRef> = (0..indices.len()).map(|_| zeroed_cell_ref()).collect();
+        let err = validate_recovery_inputs(&indices, &cells).unwrap_err();
+        assert!(matches!(err, RecoveryError::CellIndicesNotUnique));
+    }
+
+    #[test]
+    fn test_empty_input_should_fail_not_enough() {
+        let indices = vec![];
+        let cells: Vec<CellRef> = vec![];
+        let err = validate_recovery_inputs(&indices, &cells).unwrap_err();
+        assert!(matches!(
+            err,
+            RecoveryError::NotEnoughCellsToReconstruct { .. }
+        ));
+    }
+
+    #[test]
+    fn test_max_cells_is_valid() {
+        let (indices, cells) = make_valid_inputs(CELLS_PER_EXT_BLOB);
+        assert!(validate_recovery_inputs(&indices, &cells).is_ok());
     }
 }

--- a/crates/eip7594/src/recovery.rs
+++ b/crates/eip7594/src/recovery.rs
@@ -54,7 +54,7 @@ pub(crate) fn recover_polynomial_coeff(
         .expect("infallible: could not recover evaluations in domain order");
 
     // Find all of the missing cell indices. This is needed for recovery.
-let missing_cell_indices = find_missing_cell_indices(&cell_indices_normal_order);
+    let missing_cell_indices = find_missing_cell_indices(&cell_indices_normal_order);
 
     // Recover the polynomial in monomial form, that one can use to generate the cells.
     let recovered_polynomial_coeff = rs.recover_polynomial_coefficient(


### PR DESCRIPTION
- The logic of `find_missing_cell_indices` seemed to be very simple and only used at one place so I just moved the logic there to rm the function.
- Header doc is added to the functions to better explain their utility.
- The `validation` module is removed with a more descriptive name for `validate_recovery_inputs` in order to avoid same naming with `rs.recover_polynomial_coefficient`
- Unit tests are added to check some validation cases.