### PR TITLE
chore: add unit test and check for `ToeplitzMatrix`

### DIFF
--- a/crates/cryptography/kzg_multi_open/src/fk20/batch_toeplitz.rs
+++ b/crates/cryptography/kzg_multi_open/src/fk20/batch_toeplitz.rs
@@ -168,7 +168,7 @@ mod tests {
         fixed_base_msm::UsePrecomp, g1_batch_normalize, group::Group, G1Projective, Scalar,
     };
 
-    use crate::fk20::{batch_toeplitz::BatchToeplitzMatrixVecMul, toeplitz::ToeplitzMatrix};
+    use super::*;
 
     #[test]
     fn smoke_aggregated_matrix_vector_mul() {

--- a/crates/cryptography/kzg_multi_open/src/fk20/toeplitz.rs
+++ b/crates/cryptography/kzg_multi_open/src/fk20/toeplitz.rs
@@ -194,7 +194,7 @@ mod tests {
 
             // Compute the circulant domain
             let domain = polynomial::domain::Domain::new(vector.len() * 2);
-            // Compute the fft of the
+            // Compute the fft of the vector
             let m_fft = domain.fft_g1(vector);
             let col_fft = domain.fft_scalars(self.row.into());
 


### PR DESCRIPTION
A check is added to verify that during the construction of `ToeplitzMatrix`, `col[0] == row[0]` with an associated unit test to protect this behaviour.