### PR TITLE
chore: rm prover and verifier sub-modules for kzg-open

### DIFF
--- a/crates/eip4844/src/kzg_open.rs
+++ b/crates/eip4844/src/kzg_open.rs
@@ -1,4 +1,10 @@
-use bls12_381::Scalar;
+use bls12_381::{
+    lincomb::g1_lincomb, multi_pairings, traits::Curve, G1Point, G2Point, G2Prepared, Scalar,
+};
+use itertools::{chain, cloned, izip, Itertools};
+use polynomial::domain::Domain;
+
+use crate::{trusted_setup::TrustedSetup, VerifierError};
 
 pub(crate) fn bitreverse(mut n: u32, l: u32) -> u32 {
     let mut r = 0;
@@ -46,141 +52,124 @@ pub(crate) fn divide_by_linear(poly: &[Scalar], z: Scalar) -> (Vec<Scalar>, Scal
     (quotient, remainder)
 }
 
-pub mod verifier {
-    use bls12_381::{
-        lincomb::g1_lincomb, multi_pairings, traits::*, G1Point, G2Point, G2Prepared, Scalar,
-    };
-    use itertools::{chain, cloned, izip, Itertools};
-    use polynomial::domain::Domain;
+/// The key that is used to verify KZG single-point opening proofs.
+pub struct VerificationKey {
+    pub gen_g1: G1Point,
+    pub gen_g2: G2Point,
+    pub tau_g2: G2Point,
+}
 
-    use crate::{trusted_setup::TrustedSetup, VerifierError};
+pub struct Verifier {
+    /// Domain used to create the opening proofs.
+    pub domain: Domain,
+    /// Verification key used to verify KZG single-point opening proofs.
+    pub verification_key: VerificationKey,
+}
 
-    /// The key that is used to verify KZG single-point opening proofs.
-    pub struct VerificationKey {
-        pub gen_g1: G1Point,
-        pub gen_g2: G2Point,
-        pub tau_g2: G2Point,
+impl Verifier {
+    pub fn new(domain_size: usize, trusted_setup: &TrustedSetup) -> Self {
+        Self {
+            domain: Domain::new(domain_size),
+            verification_key: VerificationKey::from(trusted_setup),
+        }
     }
 
-    pub struct Verifier {
-        /// Domain used to create the opening proofs.
-        pub domain: Domain,
-        /// Verification key used to verify KZG single-point opening proofs.
-        pub verification_key: VerificationKey,
+    pub fn verify_kzg_proof(
+        &self,
+        commitment: G1Point,
+        z: Scalar,
+        y: Scalar,
+        proof: G1Point,
+    ) -> Result<(), VerifierError> {
+        let vk = &self.verification_key;
+
+        // [f(τ) - f(z)]G₁
+        let lhs_g1 = (commitment - vk.gen_g1 * y).to_affine();
+
+        // [-1]G₂
+        let lhs_g2 = G2Prepared::from(-vk.gen_g2);
+
+        // [q(τ)]G₁
+        let rhs_g1 = proof;
+
+        // [τ - z]G₂
+        let rhs_g2 = G2Prepared::from((vk.tau_g2 - vk.gen_g2 * z).to_affine());
+
+        // Check whether `f(τ) - f(z) == q(τ) * (τ - z)`
+        multi_pairings(&[(&lhs_g1, &lhs_g2), (&rhs_g1, &rhs_g2)])
+            .then_some(())
+            .ok_or(VerifierError::InvalidProof)
     }
 
-    impl Verifier {
-        pub fn new(domain_size: usize, trusted_setup: &TrustedSetup) -> Self {
-            Self {
-                domain: Domain::new(domain_size),
-                verification_key: VerificationKey::from(trusted_setup),
-            }
-        }
+    pub fn verify_kzg_proof_batch(
+        &self,
+        commitments: &[G1Point],
+        zs: &[Scalar],
+        ys: &[Scalar],
+        proofs: &[G1Point],
+        r_powers: &[Scalar],
+    ) -> Result<(), VerifierError> {
+        assert!(
+            commitments.len() == zs.len()
+                && commitments.len() == ys.len()
+                && commitments.len() == proofs.len()
+                && commitments.len() == r_powers.len()
+        );
 
-        pub fn verify_kzg_proof(
-            &self,
-            commitment: G1Point,
-            z: Scalar,
-            y: Scalar,
-            proof: G1Point,
-        ) -> Result<(), VerifierError> {
-            let vk = &self.verification_key;
+        let vk = &self.verification_key;
 
-            // [f(τ) - f(z)]G₁
-            let lhs_g1 = (commitment - vk.gen_g1 * y).to_affine();
-
-            // [-1]G₂
-            let lhs_g2 = G2Prepared::from(-vk.gen_g2);
-
-            // [q(τ)]G₁
-            let rhs_g1 = proof;
-
-            // [τ - z]G₂
-            let rhs_g2 = G2Prepared::from((vk.tau_g2 - vk.gen_g2 * z).to_affine());
-
-            // Check whether `f(τ) - f(z) == q(τ) * (τ - z)`
-            multi_pairings(&[(&lhs_g1, &lhs_g2), (&rhs_g1, &rhs_g2)])
-                .then_some(())
-                .ok_or(VerifierError::InvalidProof)
-        }
-
-        pub fn verify_kzg_proof_batch(
-            &self,
-            commitments: &[G1Point],
-            zs: &[Scalar],
-            ys: &[Scalar],
-            proofs: &[G1Point],
-            r_powers: &[Scalar],
-        ) -> Result<(), VerifierError> {
-            assert!(
-                commitments.len() == zs.len()
-                    && commitments.len() == ys.len()
-                    && commitments.len() == proofs.len()
-                    && commitments.len() == r_powers.len()
-            );
-
-            let vk = &self.verification_key;
-
-            // \sum (r^i * [f_i(τ)]G₁) - [\sum (r^i * y_i)]G₁ + \sum (r^i * z_i * [q(τ)]G₁)
-            let lhs_g1 = {
-                let points = chain![commitments, [&vk.gen_g1], proofs]
-                    .copied()
-                    .collect_vec();
-                let scalars = {
-                    // \sum r^i * y_i
-                    let y_lincomb: Scalar = izip!(r_powers, ys).map(|(r_i, y_i)| r_i * y_i).sum();
-                    let r_z = r_powers.iter().zip(zs).map(|(r_i, z_i)| r_i * z_i);
-                    chain![cloned(r_powers), [-y_lincomb], r_z].collect_vec()
-                };
-                g1_lincomb(&points, &scalars)
-                    .expect("points.len() == scalars.len()")
-                    .to_affine()
+        // \sum (r^i * [f_i(τ)]G₁) - [\sum (r^i * y_i)]G₁ + \sum (r^i * z_i * [q(τ)]G₁)
+        let lhs_g1 = {
+            let points = chain![commitments, [&vk.gen_g1], proofs]
+                .copied()
+                .collect_vec();
+            let scalars = {
+                // \sum r^i * y_i
+                let y_lincomb: Scalar = izip!(r_powers, ys).map(|(r_i, y_i)| r_i * y_i).sum();
+                let r_z = r_powers.iter().zip(zs).map(|(r_i, z_i)| r_i * z_i);
+                chain![cloned(r_powers), [-y_lincomb], r_z].collect_vec()
             };
+            g1_lincomb(&points, &scalars)
+                .expect("points.len() == scalars.len()")
+                .to_affine()
+        };
 
-            // \sum r^i * [q(τ)]G₁
-            let rhs_g1 = g1_lincomb(proofs, r_powers)
-                .expect("proofs.len() == r_powers.len()")
-                .to_affine();
+        // \sum r^i * [q(τ)]G₁
+        let rhs_g1 = g1_lincomb(proofs, r_powers)
+            .expect("proofs.len() == r_powers.len()")
+            .to_affine();
 
-            // [-1]G₂
-            let lhs_g2 = G2Prepared::from(-vk.gen_g2);
+        // [-1]G₂
+        let lhs_g2 = G2Prepared::from(-vk.gen_g2);
 
-            // [τ]G₂
-            let rhs_g2 = G2Prepared::from(vk.tau_g2);
+        // [τ]G₂
+        let rhs_g2 = G2Prepared::from(vk.tau_g2);
 
-            // Check whether `\sum (r^i * (f_i(τ) - y_i)) + \sum (r^i * z_i * q(τ)) == \sum (r^i * τ * q(τ))`
-            multi_pairings(&[(&lhs_g1, &lhs_g2), (&rhs_g1, &rhs_g2)])
-                .then_some(())
-                .ok_or(VerifierError::InvalidProof)
-        }
+        // Check whether `\sum (r^i * (f_i(τ) - y_i)) + \sum (r^i * z_i * q(τ)) == \sum (r^i * τ * q(τ))`
+        multi_pairings(&[(&lhs_g1, &lhs_g2), (&rhs_g1, &rhs_g2)])
+            .then_some(())
+            .ok_or(VerifierError::InvalidProof)
     }
 }
 
-pub mod prover {
-    use bls12_381::G1Point;
-    use polynomial::domain::Domain;
+/// The key that is used to commit to polynomials in monomial form.
+pub struct CommitKey {
+    pub g1s: Vec<G1Point>,
+}
 
-    use crate::TrustedSetup;
+pub struct Prover {
+    /// Domain used to create the opening proofs.
+    pub domain: Domain,
+    /// Commitment key used for committing to the polynomial
+    /// in monomial form
+    pub commit_key: CommitKey,
+}
 
-    /// The key that is used to commit to polynomials in monomial form.
-    pub struct CommitKey {
-        pub g1s: Vec<G1Point>,
-    }
-
-    pub struct Prover {
-        /// Domain used to create the opening proofs.
-        pub domain: Domain,
-        /// Commitment key used for committing to the polynomial
-        /// in monomial form
-        pub commit_key: CommitKey,
-    }
-
-    impl Prover {
-        pub fn new(domain_size: usize, trusted_setup: &TrustedSetup) -> Self {
-            Self {
-                domain: Domain::new(domain_size),
-                commit_key: CommitKey::from(trusted_setup),
-            }
+impl Prover {
+    pub fn new(domain_size: usize, trusted_setup: &TrustedSetup) -> Self {
+        Self {
+            domain: Domain::new(domain_size),
+            commit_key: CommitKey::from(trusted_setup),
         }
     }
 }

--- a/crates/eip4844/src/lib.rs
+++ b/crates/eip4844/src/lib.rs
@@ -17,7 +17,7 @@ mod trusted_setup;
 pub use errors::{Error, SerializationError, VerifierError};
 pub use trusted_setup::TrustedSetup;
 
-use crate::kzg_open::{prover::Prover, verifier::Verifier};
+use crate::kzg_open::{Prover, Verifier};
 
 /// BlobRef denotes a references to an opaque Blob.
 ///

--- a/crates/eip4844/src/trusted_setup.rs
+++ b/crates/eip4844/src/trusted_setup.rs
@@ -1,7 +1,7 @@
 use bls12_381::{G1Point, G2Point};
 use serde::Deserialize;
 
-use crate::kzg_open::{prover::CommitKey, verifier::VerificationKey};
+use crate::kzg_open::{CommitKey, VerificationKey};
 
 const TRUSTED_SETUP_JSON: &str = include_str!("../../eip7594/data/trusted_setup_4096.json");
 


### PR DESCRIPTION
@kevaundray I don't know if you agree with this change, but it seemed strange to me to have submodules in the same file, especially since I believe we're re-exporting what's inside them in the module higher up in the hierarchy. Maybe this is more straightforward to have everything at the same level here?

Feel free to close if you find this inappropriate?