### PR TITLE
chore: rename `invalid_proof` to `is_fk20_verification_failure`

### DIFF
--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -259,7 +259,7 @@ fn verification_result_to_bool_cresult(
 ) -> Result<bool, CResult> {
     match verification_result {
         Ok(_) => Ok(true),
-        Err(x) if x.invalid_proof() => Ok(false),
+        Err(x) if x.is_fk20_verification_failure() => Ok(false),
         Err(err) => Err(CResult::with_error(&format!("{:?}", err))),
     }
 }

--- a/bindings/java/rust_code/src/lib.rs
+++ b/bindings/java/rust_code/src/lib.rs
@@ -161,7 +161,7 @@ fn verify_cell_kzg_proof_batch<'local>(
 
     match ctx.verify_cell_kzg_proof_batch(commitments, &cell_indices, cells, proofs) {
         Ok(()) => Ok(jboolean::from(true)),
-        Err(x) if x.invalid_proof() => Ok(jboolean::from(false)),
+        Err(x) if x.is_fk20_verification_failure() => Ok(jboolean::from(false)),
         Err(err) => Err(Error::Cryptography(err)),
     }
 }

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -235,7 +235,7 @@ impl DASContextJs {
     let valid = ctx.verify_cell_kzg_proof_batch(commitments, &cell_indices, cells, proofs);
     match valid {
       Ok(_) => Ok(true),
-      Err(x) if x.invalid_proof() => Ok(false),
+      Err(x) if x.is_fk20_verification_failure() => Ok(false),
       Err(err) => Err(Error::from_reason(format!(
         "failed to compute verify_cell_kzg_proof_batch: {:?}",
         err

--- a/crates/eip7594/src/errors.rs
+++ b/crates/eip7594/src/errors.rs
@@ -20,7 +20,7 @@ impl Error {
     ///
     /// Note: This distinction in practice, is not meaningful for the caller and is mainly
     /// here due to the specs and spec tests making this distinction.
-    pub const fn invalid_proof(&self) -> bool {
+    pub const fn is_fk20_verification_failure(&self) -> bool {
         matches!(self, Self::Verifier(VerifierError::FK20(_)))
     }
 }

--- a/crates/eip7594/tests/verify_cell_kzg_proof_batch.rs
+++ b/crates/eip7594/tests/verify_cell_kzg_proof_batch.rs
@@ -129,7 +129,7 @@ fn test_verify_cell_kzg_proof_batch() {
                 // We arrive at this point if the proof verified as true
                 assert!(test.output.unwrap());
             }
-            Err(x) if x.invalid_proof() => {
+            Err(x) if x.is_fk20_verification_failure() => {
                 assert!(!test.output.unwrap());
             }
             Err(_) => {


### PR DESCRIPTION
To be more descriptive with what the function is doing.