### PR TITLE
feat(nodejs): support number or bigint input

### DIFF
--- a/bindings/node/index.d.ts
+++ b/bindings/node/index.d.ts
@@ -26,10 +26,10 @@ export class DasContextJs {
   asyncComputeCellsAndKzgProofs(blob: Uint8Array): Promise<CellsAndProofs>
   computeCells(blob: Uint8Array): Array<Uint8Array>
   asyncComputeCells(blob: Uint8Array): Promise<Array<Uint8Array>>
-  recoverCellsAndKzgProofs(cellIndices: Array<bigint>, cells: Array<Uint8Array>): CellsAndProofs
-  asyncRecoverCellsAndKzgProofs(cellIndices: Array<bigint>, cells: Array<Uint8Array>): Promise<CellsAndProofs>
-  verifyCellKzgProofBatch(commitments: Array<Uint8Array>, cellIndices: Array<bigint>, cells: Array<Uint8Array>, proofs: Array<Uint8Array>): boolean
-  asyncVerifyCellKzgProofBatch(commitments: Array<Uint8Array>, cellIndices: Array<bigint>, cells: Array<Uint8Array>, proofs: Array<Uint8Array>): Promise<boolean>
+  recoverCellsAndKzgProofs(cellIndices: Array<number | bigint>, cells: Array<Uint8Array>): CellsAndProofs
+  asyncRecoverCellsAndKzgProofs(cellIndices: Array<number | bigint>, cells: Array<Uint8Array>): Promise<CellsAndProofs>
+  verifyCellKzgProofBatch(commitments: Array<Uint8Array>, cellIndices: Array<number | bigint>, cells: Array<Uint8Array>, proofs: Array<Uint8Array>): boolean
+  asyncVerifyCellKzgProofBatch(commitments: Array<Uint8Array>, cellIndices: Array<number | bigint>, cells: Array<Uint8Array>, proofs: Array<Uint8Array>): Promise<boolean>
   computeKzgProof(blob: Uint8Array, z: Uint8Array): Array<Uint8Array>
   asyncComputeKzgProof(blob: Uint8Array, z: Uint8Array): Promise<Array<Uint8Array>>
   computeBlobKzgProof(blob: Uint8Array, commitment: Uint8Array): Uint8Array


### PR DESCRIPTION
Motivation:
- In practice, indices are quite small and don't need to be bigint
- It's convenient (and more performant) to use number when indices are small

Description:
- Convert functions with `Vec<BigInt>` params to `Vec<Either<u32, BigInt>>`
- Convert `bigint_to_u64` to `u32_or_bigint_to_u64`