### PR TITLE
chore: add assertion that cosets are the same size

### DIFF
--- a/crates/cryptography/kzg_multi_open/src/fk20/verifier.rs
+++ b/crates/cryptography/kzg_multi_open/src/fk20/verifier.rs
@@ -138,6 +138,14 @@ impl FK20Verifier {
             bit_reversed_proofs.len(),
             "Expected to have a proof for each evaluation we want to prove an opening for"
         );
+        let all_same_size = bit_reversed_coset_evals
+            .windows(2)
+            .all(|w| w[0].len() == w[1].len());
+        assert!(
+            all_same_size,
+            "Expected all cosets to have the same number of elements"
+        );
+
         // The batch size corresponds to how many openings, we ultimately want to be verifying.
         let batch_size = bit_reversed_coset_indices.len();
 


### PR DESCRIPTION
Taken from zk security audit