### PR TITLE
chore: Fix typo 96 bytes instead of 48

### DIFF
--- a/crates/cryptography/bls12_381/src/fixed_base_msm_window.rs
+++ b/crates/cryptography/bls12_381/src/fixed_base_msm_window.rs
@@ -56,7 +56,7 @@ impl FixedBaseMSMPrecompWindow {
         // 1 * P, ..., (2^{wbits} - 1) * P
         //
         // The total amount of memory is roughly (numPoints * 2^{wbits} - 1)
-        // where each point is 64 bytes.
+        // where each point is 96 bytes.
         let table = points
             .iter()
             .map(|point| Self::precompute_points(wbits, *point))


### PR DESCRIPTION
This came from the zkSecurity audit