### PR TITLE
chore: filter out identity points in blst msm

### DIFF
--- a/crates/cryptography/bls12_381/Cargo.toml
+++ b/crates/cryptography/bls12_381/Cargo.toml
@@ -14,9 +14,12 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# We want at least 0.3.15 because this is where the fix for points at infinity was added.
-# See: https://github.com/supranational/blst/commit/ae643bad61ac6fd618bffd771d0ccfddfddf8aee
-blst = { version = "0.3.15", default-features = false }
+# We want at least 0.3.16 because this is where the fix for points at infinity was added.
+# See: 
+# - https://github.com/supranational/blst/commit/ae643bad61ac6fd618bffd771d0ccfddfddf8aee
+# - https://github.com/supranational/blst/commit/7c535f1afcea92a4ff3103e73d937604122cce5e
+# - https://github.com/supranational/blst/commit/f48500c1fdbefa7c0bf9800bccd65d28236799c1
+blst = { version = "0.3.16", default-features = false }
 
 # __private_bench feature is used to allow us to access the base field
 blstrs = { version = "0.7.1", features = ["__private_bench", "portable"] }

--- a/crates/cryptography/bls12_381/Cargo.toml
+++ b/crates/cryptography/bls12_381/Cargo.toml
@@ -14,12 +14,7 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# We want at least 0.3.16 because this is where the fix for points at infinity was added.
-# See: 
-# - https://github.com/supranational/blst/commit/ae643bad61ac6fd618bffd771d0ccfddfddf8aee
-# - https://github.com/supranational/blst/commit/7c535f1afcea92a4ff3103e73d937604122cce5e
-# - https://github.com/supranational/blst/commit/f48500c1fdbefa7c0bf9800bccd65d28236799c1
-blst = { version = "0.3.16", default-features = false }
+blst = { version = ">=0.3.16", default-features = false }
 
 # __private_bench feature is used to allow us to access the base field
 blstrs = { version = "0.7.1", features = ["__private_bench", "portable"] }

--- a/crates/cryptography/bls12_381/src/lincomb.rs
+++ b/crates/cryptography/bls12_381/src/lincomb.rs
@@ -9,10 +9,6 @@ pub fn g1_lincomb(points: &[G1Point], scalars: &[Scalar]) -> Option<G1Projective
         return None;
     }
 
-    if points.is_empty() {
-        return Some(G1Projective::identity());
-    }
-
     // Filter out identity points
     let (points, scalars): (Vec<_>, Vec<_>) = points
         .iter()
@@ -20,6 +16,11 @@ pub fn g1_lincomb(points: &[G1Point], scalars: &[Scalar]) -> Option<G1Projective
         .filter(|(point, _)| !(bool::from(point.is_identity())))
         .map(|(point, scalar)| (G1Projective::from(point), *scalar))
         .unzip();
+
+    // Return group identity if no valid points remain
+    if points.is_empty() {
+        return Some(G1Projective::identity());
+    }
 
     Some(G1Projective::multi_exp(&points, &scalars))
 }
@@ -33,11 +34,6 @@ pub fn g2_lincomb(points: &[G2Point], scalars: &[Scalar]) -> Option<G2Projective
         return None;
     }
 
-    // Return group identity if no valid points remain
-    if points.is_empty() {
-        return Some(G2Projective::identity());
-    }
-
     // Filter out identity points
     let (points, scalars): (Vec<_>, Vec<_>) = points
         .iter()
@@ -46,11 +42,17 @@ pub fn g2_lincomb(points: &[G2Point], scalars: &[Scalar]) -> Option<G2Projective
         .map(|(point, scalar)| (G2Projective::from(point), *scalar))
         .unzip();
 
+    // Return group identity if no valid points remain
+    if points.is_empty() {
+        return Some(G2Projective::identity());
+    }
+
     Some(G2Projective::multi_exp(&points, &scalars))
 }
 
 #[cfg(test)]
 mod tests {
+    use blstrs::G1Projective;
     use rand::{rngs::StdRng, SeedableRng};
 
     use super::*;
@@ -70,6 +72,16 @@ mod tests {
         let points = vec![G1Point::generator()];
         let scalars = vec![];
         assert_eq!(g1_lincomb(&points, &scalars), None);
+    }
+
+    #[test]
+    fn g1_lincomb_filters_out_identity_points() {
+        let points = vec![G1Point::identity()];
+        let scalars = vec![Scalar::from(1)];
+        assert_eq!(
+            g1_lincomb(&points, &scalars),
+            Some(G1Projective::identity())
+        );
     }
 
     #[test]

--- a/crates/cryptography/bls12_381/src/lincomb.rs
+++ b/crates/cryptography/bls12_381/src/lincomb.rs
@@ -13,9 +13,15 @@ pub fn g1_lincomb(points: &[G1Point], scalars: &[Scalar]) -> Option<G1Projective
         return Some(G1Projective::identity());
     }
 
-    // Convert to Projective, since the API forces us to do this
-    let proj_points: Vec<_> = points.iter().map(Into::into).collect();
-    Some(G1Projective::multi_exp(&proj_points, scalars))
+    // Filter out identity points
+    let (points, scalars): (Vec<_>, Vec<_>) = points
+        .iter()
+        .zip(scalars)
+        .filter(|(point, _)| !(bool::from(point.is_identity())))
+        .map(|(point, scalar)| (G1Projective::from(point), *scalar))
+        .unzip();
+
+    Some(G1Projective::multi_exp(&points, &scalars))
 }
 
 /// A multi-scalar multiplication algorithm over G2 elements
@@ -32,10 +38,15 @@ pub fn g2_lincomb(points: &[G2Point], scalars: &[Scalar]) -> Option<G2Projective
         return Some(G2Projective::identity());
     }
 
-    // Convert to Projective, since the API forces us to do this
-    let proj_points: Vec<_> = points.iter().map(Into::into).collect();
+    // Filter out identity points
+    let (points, scalars): (Vec<_>, Vec<_>) = points
+        .iter()
+        .zip(scalars)
+        .filter(|(point, _)| !(bool::from(point.is_identity())))
+        .map(|(point, scalar)| (G2Projective::from(point), *scalar))
+        .unzip();
 
-    Some(G2Projective::multi_exp(&proj_points, scalars))
+    Some(G2Projective::multi_exp(&points, &scalars))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
We had an issue where blst was not correctly treating the identity point -- this should have been fixed as of 0.3.16 but we are adding this defensive assert code here anyways